### PR TITLE
Fix inner links in launch-a-chain guide

### DIFF
--- a/pop-cli-for-appchains/guides/launch-a-chain/launch-a-chain-to-paseo.md
+++ b/pop-cli-for-appchains/guides/launch-a-chain/launch-a-chain-to-paseo.md
@@ -9,7 +9,7 @@ description: >-
 
 #### Paseo Local
 
-If you want to test onboarding a chain on your local machine you need to [launch Paseo](spinning-up-the-polkadot-network).
+If you want to test onboarding a chain on your local machine you need to [launch Paseo](spinning-up-the-polkadot-network.md).
 
 #### Paseo Live
 
@@ -19,7 +19,7 @@ Otherwise you will onboard to [Paseo](https://polkadot.js.org/apps/?rpc=wss%3A%2
 
 ## Generate Operational Keys
 
-See here how to [generate keys](./keys).
+See here how to [generate keys](keys.md).
 
 ### Collator Keys
 


### PR DESCRIPTION
These two inner links were broken since they were missing the `.md`