### PR TITLE
docs: guide to test runtime upgrades

### DIFF
--- a/pop-cli-for-appchains/README.md
+++ b/pop-cli-for-appchains/README.md
@@ -21,6 +21,7 @@ With Pop CLI, developers can build an appchain on Polkadot.
 * Spin up a Polkadot network with various parachains
   * Useful for testing cross-chain interoperability
 * Benchmarking of nodes and runtimes&#x20;
+* Testing a runtime&#x20;
 
 **Get started with your first Polkadot appchain:**
 

--- a/pop-cli-for-appchains/SUMMARY.md
+++ b/pop-cli-for-appchains/SUMMARY.md
@@ -30,6 +30,7 @@
   * [Deploy a chain with Polkadot Deployment Portal](guides/launch-a-chain/deploy-a-chain-polkadot-deployment-portal.md)
   * [Running a post-startup command](guides/running-a-post-startup-command.md)
 * [Securely Sign Transactions from CLI](guides/securely-sign-transactions-from-cli.md)
+* [Test runtime upgrades](guides/test-runtime-upgrades.md)
 
 ## POP CLI
 
@@ -42,3 +43,4 @@
 * [call](pop-cli/call.md)
 * [up](pop-cli/up.md)
 * [clean](pop-cli/clean.md)
+* [test](pop-cli/test.md)

--- a/pop-cli-for-appchains/guides/test-runtime-upgrades.md
+++ b/pop-cli-for-appchains/guides/test-runtime-upgrades.md
@@ -1,0 +1,157 @@
+---
+description: The following guide shows how to test runtime upgrades.
+---
+
+# Testing Runtime Upgrades
+
+A key feature of Substrate is its support for forkless upgrades. Testing the blockchain runtime upgrade process is essential to ensure a seamless network transition without disruptions.
+
+To simulate and validate the process of upgrading a blockchain's runtime, the `on-runtime-upgrade` executes the [`OnRuntimeUpgrade`](https://paritytech.github.io/polkadot-sdk/master/frame_support/traits/trait.OnRuntimeUpgrade.html) hooks of a runtime against the state of a live blockchain or a snapshot.
+
+Hence, there are two subcommands `live` and `snap` to specify the source of the runtime state.
+
+```bash
+Usage: pop test on-runtime-upgrade [OPTIONS] [COMMAND]
+
+Commands:
+  live  A live chain
+  snap  A state snapshot
+  help  Print this message or the help of the given subcommand(s)
+```
+
+## Test migrations
+
+By running the command `pop test on-runtime-upgrade`, you can test the [Runtime Upgrades](https://docs.polkadot.com/develop/parachains/maintenance/runtime-upgrades/) and [Storage Migrations](https://docs.polkadot.com/develop/parachains/maintenance/storage-migrations/) in a simulated environment.
+
+```bash
+┌   Pop CLI : Testing migrations
+│
+◆  Do you want to specify which runtime to run the migration on?
+│  If not provided, use the code of the remote node, or a snapshot.
+│  ● Yes  / ○ No
+└
+```
+
+Before the migration running, you will be prompted to confirm if you want to specify which runtime to run the migration on:
+
+- If you choose to specify, you will be prompted to select the runtime to run the migration on. The feature requires your runtime to be [built with `--try-runtime` feature](../pop-cli/build.md).
+
+> Pop CLI will automatically locate the runtime binary based on the provided `--profile`. Pop CLI will automatically build the runtime if not found.
+
+- If not, the migration will be run against the code that's currently running on the remote node or the one stored inside the snapshot file you provide.
+
+> Snapshot can be created with `pop test create-snapshot`.
+
+
+### Test migrations against a live chain
+
+```bash
+◆  Select source of runtime state:
+│  ● Live (Run the migrations on top of live state.)
+│  ○ Snapshot
+|
+◇  Enter the live chain of your node:
+│  wss://rpc1.paseo.popnetwork.xyz
+│
+◆  Enter the block hash (optional):
+│  0x1234567890abcdef1234567890abcdef
+└
+```
+
+You'll be asked to enter the URI of a live node and optionally provide a block hash. If a [block hash](https://paritytech.github.io/polkadot-sdk/master/sp_runtime/traits/trait.HashOutput.html) is given, the state will be executed at the specified block hash on the provided network.
+
+To run the migrations on top of live state manually:
+
+```bash
+pop test on-runtime-upgrade \
+    --runtime=<path_to_runtime_binary> \
+    live \
+    --uri=wss://rpc1.paseo.popnetwork.xyz \
+    --at=0x1234567890abcdef1234567890abcdef
+```
+
+**_Note_**: The specified runtime and the remote node's runtime must have the same name and version. If not, the migration will fail. You can add the flag `--disable-spec-version-check` and `--disable-spec-name-check` to bypass the checks.
+
+```bash
+pop test on-runtime-upgrade \
+    --runtime=<path_to_runtime_binary> \
+    --disable-spec-version-check \
+    --disable-spec-name-check \
+    live \
+    --uri=wss://rpc1.paseo.popnetwork.xyz \
+    --at=0x1234567890abcdef1234567890abcdef
+```
+
+After that, you can select select the upgrade checks to perform:
+
+```bash
+◆  Select upgrade checks to perform:
+│  ○ none
+│  ● all (Run the `try_state`, `pre_upgrade` and `post_upgrade` checks)
+│  ○ try-state
+│  ○ pre-and-post
+└
+```
+
+### Test migrations with a snapshot file
+
+A second approach to test migrations is with a snapshot file. First, you need to create a snapshot file of a live network. You can do this by running the following command:
+
+```bash
+pop test create-snapshot
+```
+
+The interactive interface to prompts for the live URI and the path of the snapshot file:
+
+```bash
+┌   Pop CLI : Creating a snapshot file
+│
+▲  NOTE: `create-snapshot` only works with the remote node. No runtime required.
+│
+◇  Enter the URI of the remote node:
+│  wss://rpc1.paseo.popnetwork.xyz
+│
+◇  Enter the path to write the snapshot to (optional):
+│  If not provided `<spec-name>-<spec-version>@<block-hash>.snap` will be used.
+│  example.snap
+```
+
+To skip the interactive prompt, use the `--uri` and `--path` flags:
+
+```bash
+pop test create-snapshot --uri wss://rpc1.paseo.popnetwork.xyz ./example.snap
+```
+
+If the path of snapshot file is not provided, the default name following a format `<spec-name>-<spec-version>@<block-hash>.snap` will be used. Note that the remote node must be built with `--try-runtime` feature enabled.
+
+Assume there is a snapshot file created with the name `example.snap`:
+
+```bash
+◇  Enter path to your snapshot file?
+│  Snapshot file can be generated using `pop test create-snapshot` command.
+│  ./example.snap
+```
+
+To run migrations with a snapshot manually:
+
+```bash
+pop test on-runtime-upgrade \
+    --runtime=<path_to_runtime_binary> \
+    --blocktime=6000 \
+    --checks=all \
+    snap \
+    --path=./example.snap
+```
+
+#### Learning Resources
+
+* 🧑‍🏫 To learn about Polkadot in general, [Polkadot.network](https://polkadot.network/) website is a good starting point.
+* 🧑‍🔧 For technical introduction, [here](https://github.com/paritytech/polkadot-sdk#-documentation) are the Polkadot SDK documentation resources.
+
+* Learn more about [Runtime Upgrades](https://docs.polkadot.com/develop/parachains/maintenance/runtime-upgrades/) and [Storage Migrations](https://docs.polkadot.com/develop/parachains/maintenance/storage-migrations).
+
+**Technical Support**
+
+* [Polkadot Stack Exchange](https://polkadot.stackexchange.com/)
+  * Create a question and tag it with "[`pop`](https://substrate.stackexchange.com/tags/pop/info)"
+  * Share the StackExchange question in our [Pop Support Telegram channel](https://t.me/pop\_support)

--- a/pop-cli-for-appchains/pop-cli/build.md
+++ b/pop-cli-for-appchains/pop-cli/build.md
@@ -40,6 +40,20 @@ cd my-appchain
 pop build --benchmark
 ```
 
+To build your chain for runtime testing, run the below command which will build your binary with the `try-runtime` feature enabled:
+
+```bash
+cd my-appchain
+pop build --try-runtime
+```
+
+On the other hand, you can also provide a list of features with the `--features` flag:
+
+```bash
+cd my-appchain
+pop build --features runtime-benchmarks,try-runtime
+```
+
 Build and generate files for onboarding the parachain to the Relay chain (Pop CLI versions >`.0.2.0`):&#x20;
 
 ```

--- a/pop-cli-for-appchains/pop-cli/test.md
+++ b/pop-cli-for-appchains/pop-cli/test.md
@@ -27,7 +27,7 @@ If you choose to run migrations on a local runtime binary, you will be prompted 
 
 If a runtime is not specified, the migration will be executed on the code currently running on the remote node of a live blockchain or the one stored in the provided snapshot file.
 
-### Test `on-runtime-upgrade live`
+### test on-runtime-upgrade live
 
 To run migrations against a live blockchain, use the `on-runtime-upgrade live` subcommand:
 

--- a/pop-cli-for-appchains/pop-cli/test.md
+++ b/pop-cli-for-appchains/pop-cli/test.md
@@ -1,0 +1,171 @@
+---
+description: Test a runtime
+---
+
+# test
+
+The Pop CLI feature is built on top of the [`try-runtime-cli`](https://github.com/paritytech/try-runtime-cli?tab=readme-ov-file), a programmatic testing framework designed for Substrate. It allows you to test runtime upgrades and state transitions.
+
+- `on-runtime-upgrade`: Tests migrations.
+- `execute-block`: Executes a specified block against some state.
+- `fast-forward`: Executes a runtime upgrade (optional), then mines a number of blocks while performing try-state checks.
+- `create-snapshot`: Creates a chain state snapshot.
+
+## test on-runtime-upgrade
+
+To test [runtime upgrades](https://docs.polkadot.com/develop/parachains/maintenance/runtime-upgrades/), you can use the `on-runtime-upgrade` subcommand. This command allows you to test migrations by executing the [`OnRuntimeUpgrade`](https://paritytech.github.io/polkadot-sdk/master/frame_support/traits/trait.OnRuntimeUpgrade.html) hooks of a runtime against the state of a live blockchain or a snapshot.
+
+```bash
+pop test on-runtime-upgrade live
+```
+
+**Note:**
+
+If you choose to run migrations on a local runtime binary, you will be prompted to provide a valid runtime binary path. [Ensure the binary is built with the `try-runtime` feature](./build.md).
+
+> Pop CLI will automatically locate the runtime binary based on the provided `--profile`. If the binary is not found, Pop CLI will build it automatically.
+
+If a runtime is not specified, the migration will be executed on the code currently running on the remote node of a live blockchain or the one stored in the provided snapshot file.
+
+### Test `on-runtime-upgrade live`
+
+To run migrations against a live blockchain, use the `on-runtime-upgrade live` subcommand:
+
+```bash
+pop test on-runtime-upgrade live
+```
+
+You'll be prompted to provide an RPC URI of a live blockchain. A valid RPC URI must start with `ws://` or `wss://`. You can also specify an optional block hash to define the state execution point.
+
+To manually provide the URI and block hash, use:
+
+```bash
+pop test on-runtime-upgrade \
+    --runtime=<path_to_runtime_binary> \
+    live \
+    --uri=wss://rpc1.paseo.popnetwork.xyz \
+    --at=0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+```
+
+### test on-runtime-upgrade snap
+
+To run migrations against a snapshot, use the `on-runtime-upgrade snap` subcommand:
+
+```bash
+pop test on-runtime-upgrade \
+    --runtime=<path_to_runtime_binary> \
+    snap \
+    --path=./example.snap
+```
+
+## test create-snapshot
+
+This command saves a copy of the blockchain's current state to a file (a snapshot). You can use this snapshot to run tests quickly instead of downloading the state from a live blockchain each time.
+
+```bash
+pop test create-snapshot
+```
+
+You'll be prompted to enter the RPC URI (the network address of the live blockchain) and the file path where the snapshot should be stored.
+
+To provide these parameters manually:
+
+```bash
+pop test create-snapshot \
+    --uri=wss://rpc1.paseo.popnetwork.xyz \
+    --path=./example.snap
+```
+
+**Note:** A live blockchain node must be [built with the `--try-runtime` feature](./build.md).
+
+## test execute-block
+
+This command executes a given number of blocks. Currently, `execute-block` only supports executing blocks against a live state. You can also specify a block hash to execute from.
+
+```bash
+pop test execute-block
+```
+
+You'll be prompted to select state tests to execute, with the following options:
+
+- **None**: No state tests will be executed.
+- **All**: Executes all available state tests.
+- **Round Robin**: Runs a fixed number of state tests in a round-robin manner.
+- **Only Pallets**: Executes only state tests related to specific pallets.
+
+Available pallets on the live network will be listed for selection:
+
+```bash
+◆  Select pallets (select with SPACE):
+│
+│  ◻ Assets
+│  ◻ Aura
+│  ◻ AuraExt
+│  ◻ Authorship
+│  ◻ Balances
+│  ◻ CollatorSelection
+│  ◻ Contracts
+│  ◻ Council
+└
+```
+
+To skip the interactive interface and provide arguments manually:
+
+```bash
+pop test execute-block \
+    --runtime=<path_to_runtime_binary> \
+    --try-state=Aura,Assets,Authorship \
+    -y \
+    --uri=wss://rpc1.paseo.popnetwork.xyz
+```
+
+For round-robin state tests, use:
+
+```bash
+pop test execute-block \
+    --runtime=<path_to_runtime_binary> \
+    --try-state=rr-10 \
+    -y \
+    --uri=wss://rpc1.paseo.popnetwork.xyz
+```
+
+## test fast-forward
+
+Executes a runtime upgrade (optional), then mines a number of blocks while performing try-state checks.
+
+```bash
+pop test fast-forward
+```
+
+You'll be prompted to specify the number of blocks to mine and whether to run pending migrations before fast-forwarding.
+
+```bash
+◇  How many empty blocks should be processed?
+│  10
+│
+◆  Do you want to run pending migrations before fast-forwarding?
+│  ● Yes  / ○ No
+└
+```
+
+Like `on-runtime-upgrade`, `fast-forward` supports `live` and `snap` subcommands to define the source of the runtime state.
+
+To skip the interactive interface and specify arguments manually:
+
+```bash
+pop test fast-forward \
+    --n-blocks 10 \
+    --run-migrations \
+    live \
+    --uri=wss://rpc1.paseo.popnetwork.xyz
+```
+
+**Note:**
+
+If you run migrations on a local runtime binary, you will be prompted to provide a valid runtime binary path. [Ensure the binary is built with the `try-runtime` feature](./build.md).
+
+> Pop CLI will automatically locate the runtime binary based on the provided `--profile`. If the binary is not found, it will be built automatically.
+
+### Learning Resources
+
+- Learn more about [Runtime Upgrades](https://docs.polkadot.com/develop/parachains/maintenance/runtime-upgrades/) and [Storage Migrations](https://docs.polkadot.com/develop/parachains/maintenance/storage-migrations/).

--- a/pop-cli-for-appchains/pop-cli/welcome.md
+++ b/pop-cli-for-appchains/pop-cli/welcome.md
@@ -17,6 +17,7 @@ Also, check out the Guides on the left for more comprehensive documentation.
 * [build spec](https://learn.onpop.io/v/appchains/pop-cli/build#build-spec)
 * [up](up.md)
 * [clean](clean.md)
+* [test](test.md)
 
 You can also see all the available commands by running:
 


### PR DESCRIPTION
- Guide: Test runtime upgrades 
- Add `pop test` command for runtime testing. 