### PR TITLE
chore: update command to install pop-cli for inkv6

### DIFF
--- a/pop-cli-for-smart-contracts/guides/migrating-to-inkv6.md
+++ b/pop-cli-for-smart-contracts/guides/migrating-to-inkv6.md
@@ -18,7 +18,7 @@ Pop CLI supports ink! v6 through the `polkavm-contracts` feature flag.
 
 To install it from the experimental branch, run:
 ```
-cargo install --git https://github.com/r0gue-io/pop-cli.git --branch feat/polkavm-compatibility --no-default-features --locked -F polkavm-contracts,parachain,telemetry
+cargo install pop-cli --no-default-features --locked -F polkavm-contracts,parachain,telemetry
 ```
 
 > **⚠️ Note:** Make sure you're using `Rust 1.85` or higher, older versions will fail to compile. You can check your version with rustc `--version`.


### PR DESCRIPTION
After the release of pop-cli v0.8.0 https://crates.io/crates/pop-cli we can update the command to install the tool to start experimenting with inkv6! contracts