### PR TITLE
feat: update pop-install instructions from macos

### DIFF
--- a/pop-cli-for-appchains/install-pop-cli.md
+++ b/pop-cli-for-appchains/install-pop-cli.md
@@ -1,18 +1,26 @@
 # Install Pop CLI
 
-### 1. Install Rust and Cargo
+## 1. Install Pop CLI
 
+### 1.1 For MacOS
+
+```bash
+brew install r0gue-io/pop-cli/pop
+```
+
+### 1.2 For any other OS
+
+Firstly, install Rust:
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-### 2. Install Pop CLI
-
+And now build pop-cli from source and install it:
 ```bash
 cargo install --force --locked pop-cli
 ```
 
-### 3. Set up your environment
+## 2. Set up your environment
 
 ```bash
 pop install

--- a/pop-cli-for-smart-contracts/welcome/install-pop-cli.md
+++ b/pop-cli-for-smart-contracts/welcome/install-pop-cli.md
@@ -1,20 +1,26 @@
 # Install Pop CLI
 
-### 1. Install Rust and Cargo
+## 1. Install Pop CLI
 
+### 1.1 For MacOS
+
+```bash
+brew install r0gue-io/pop-cli/pop
+```
+
+### 1.2 For any other OS
+
+Firstly, install Rust:
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-### 2. Install Pop CLI
-
-> **Note:** If you want to install Pop CLI for ink! v6 support, see [Getting Started with ink! v6](migrating-to-inkv6.md).
-
+And now build pop-cli from source and install it:
 ```bash
 cargo install --force --locked pop-cli
 ```
 
-### 3. Set up your environment
+## 2. Set up your environment
 
 ```bash
 pop install


### PR DESCRIPTION
This PR updates the installation instructions to indicate the possibility to install pop-cli on MacOS using brew.