### PR TITLE
fix: broken links

### DIFF
--- a/welcome/hackathon-guide.md
+++ b/welcome/hackathon-guide.md
@@ -99,10 +99,10 @@ pop up
 ```
 
 ##### Handy Links
-- [Launch a Chain in Development](../pop-cli-for-chains/guides/launch-a-chain/running-your-chain.md)
-- [Launch a Chain to Paseo](../pop-cli-for-chains/guides/launch-a-chain/launch-a-chain-to-paseo.md)
-- [Deploy a chain with Polkadot Deployment Portal](../pop-cli-for-chains/guides/launch-a-chain/deploy-a-chain-polkadot-deployment-portal.md)
-- [Securely Sign Transactions from CLI](../pop-cli-for-chains/guides/securely-sign-transactions-from-cli.md)
+- [Launch a Chain in Development](../pop-cli-for-appchains/guides/launch-a-chain/running-your-chain.md)
+- [Launch a Chain to Paseo](../pop-cli-for-appchains/guides/launch-a-chain/launch-a-chain-to-paseo.md)
+- [Deploy a chain with Polkadot Deployment Portal](../pop-cli-for-appchains/guides/launch-a-chain/deploy-a-chain-polkadot-deployment-portal.md)
+- [Securely Sign Transactions from CLI](../pop-cli-for-appchains/guides/securely-sign-transactions-from-cli.md)
 
 
 ### Support & Contribute


### PR DESCRIPTION
Some of the handy links in Hackathon Guide page are broken. They should redirect to `pop-cli-for-appchains/`, not `pop-cli-for-chains/`.

<img width="436" height="178" alt="Screenshot 2025-11-05 at 22 44 14" src="https://github.com/user-attachments/assets/c4dc3865-58e7-4699-a8de-f87e239f7539" />
