### PR TITLE
docs: update pop install

### DIFF
--- a/pop-cli-for-appchains/install-pop-cli.md
+++ b/pop-cli-for-appchains/install-pop-cli.md
@@ -1,5 +1,13 @@
 # Install Pop CLI
 
+> **Quick install (macOS/Linux with Homebrew)**
+>
+> ```bash
+> brew install r0gue-io/pop-cli/pop
+> ```
+>
+> Need Homebrew? Follow [Install Homebrew](#install-homebrew-if-not-installed).
+
 ## 1. Install Pop CLI
 
 ### 1.1 For macOS and Linux (Homebrew)
@@ -52,11 +60,13 @@ cargo install --force --locked pop-cli
 
 ## 2. Set up your environment
 
+> **Recommended next step:** Run `pop install` to set up OS packages, Rust tooling, and optional frontend dependencies.
+>
 ```bash
 pop install
 ```
 
-`pop install` (alias `pop i`) installs OS packages, Rust tooling, and optional frontend dependencies.
+> **Warning:** `pop install` may download and run external scripts when dependencies are missing, including the official installers for Homebrew, rustup, nvm, and Bun.
 
 ### Install command flags
 
@@ -68,20 +78,6 @@ pop install
 ### Interactive prompts
 
 By default, `pop install` prompts you before installing OS packages and frontend dependencies. Use `-y` to skip all prompts.
-
-### OS packages and behavior
-
-If your OS/distro is unsupported, `pop install` prints a warning and exits without installing OS packages or tooling.
-
-| OS | Package manager | Packages installed |
-| --- | --- | --- |
-| macOS | Homebrew | `homebrew`, `protobuf`, `openssl`, `cmake`, `rustup` |
-| Arch (or compatible) | `pacman` | `curl`, `git`, `clang`, `make`, `protobuf`, `rustup` |
-| Ubuntu (or compatible) | `apt` | `git`, `clang`, `curl`, `libssl-dev`, `protobuf-compiler`, `lsof`, `pkg-config`, `rustup` |
-| Debian (or compatible) | `apt` | `git`, `clang`, `curl`, `libssl-dev`, `llvm`, `libudev-dev`, `make`, `protobuf-compiler`, `lsof`, `rustup` |
-| Red Hat (or compatible) | `yum` | `gcc`, `gcc-c++`, `make`, `cmake`, `pkgconf`, `pkgconf-pkg-config`, `clang`, `curl`, `git`, `openssl-devel`, `protobuf-compiler`, `lsof`, `rustup` |
-
-When you pass `--frontend`, `pop install` also installs `unzip` on Arch, Ubuntu, and Debian.
 
 ### Rust toolchain setup
 
@@ -105,9 +101,21 @@ This will install:
 
 If Bun installs successfully but is not on your PATH yet, Pop CLI checks the default location at `~/.bun/bin/bun`.
 
-### External scripts
+## 3. Advanced details
 
-`pop install` may download and run external scripts when dependencies are missing, including the official installers for Homebrew, rustup, nvm, and Bun.
+### OS packages and behavior
+
+If your OS/distro is unsupported, `pop install` prints a warning and exits without installing OS packages or tooling.
+
+| OS | Package manager | Packages installed |
+| --- | --- | --- |
+| macOS | Homebrew | `homebrew`, `protobuf`, `openssl`, `cmake`, `rustup` |
+| Arch (or compatible) | `pacman` | `curl`, `git`, `clang`, `make`, `protobuf`, `rustup` |
+| Ubuntu (or compatible) | `apt` | `git`, `clang`, `curl`, `libssl-dev`, `protobuf-compiler`, `lsof`, `pkg-config`, `rustup` |
+| Debian (or compatible) | `apt` | `git`, `clang`, `curl`, `libssl-dev`, `llvm`, `libudev-dev`, `make`, `protobuf-compiler`, `lsof`, `rustup` |
+| Red Hat (or compatible) | `yum` | `gcc`, `gcc-c++`, `make`, `cmake`, `pkgconf`, `pkgconf-pkg-config`, `clang`, `curl`, `git`, `openssl-devel`, `protobuf-compiler`, `lsof`, `rustup` |
+
+When you pass `--frontend`, `pop install` also installs `unzip` on Arch, Ubuntu, and Debian.
 
 **Need help?**
 

--- a/pop-cli-for-smart-contracts/welcome/install-pop-cli.md
+++ b/pop-cli-for-smart-contracts/welcome/install-pop-cli.md
@@ -1,5 +1,13 @@
 # Install Pop CLI
 
+> **Quick install (macOS/Linux with Homebrew)**
+>
+> ```bash
+> brew install r0gue-io/pop-cli/pop
+> ```
+>
+> Need Homebrew? Follow [Install Homebrew](#install-homebrew-if-not-installed).
+
 ## 1. Install Pop CLI
 
 ### 1.1 For macOS and Linux (Homebrew)
@@ -51,11 +59,13 @@ cargo install --force --locked pop-cli
 
 ## 2. Set up your environment
 
+> **Recommended next step:** Run `pop install` to set up OS packages, Rust tooling, and optional frontend dependencies.
+>
 ```bash
 pop install
 ```
 
-`pop install` (alias `pop i`) installs OS packages, Rust tooling, and optional frontend dependencies.
+> **Warning:** `pop install` may download and run external scripts when dependencies are missing, including the official installers for Homebrew, rustup, nvm, and Bun.
 
 ### Install command flags
 
@@ -68,20 +78,6 @@ pop install
 
 By default, `pop install` prompts you before installing OS packages and frontend dependencies. Use `-y` to skip all prompts.
 
-### OS packages and behavior
-
-If your OS/distro is unsupported, `pop install` prints a warning and exits without installing OS packages or tooling.
-
-| OS | Package manager | Packages installed |
-| --- | --- | --- |
-| macOS | Homebrew | `homebrew`, `protobuf`, `openssl`, `cmake`, `rustup` |
-| Arch (or compatible) | `pacman` | `curl`, `git`, `clang`, `make`, `protobuf`, `rustup` |
-| Ubuntu (or compatible) | `apt` | `git`, `clang`, `curl`, `libssl-dev`, `protobuf-compiler`, `lsof`, `pkg-config`, `rustup` |
-| Debian (or compatible) | `apt` | `git`, `clang`, `curl`, `libssl-dev`, `llvm`, `libudev-dev`, `make`, `protobuf-compiler`, `lsof`, `rustup` |
-| Red Hat (or compatible) | `yum` | `gcc`, `gcc-c++`, `make`, `cmake`, `pkgconf`, `pkgconf-pkg-config`, `clang`, `curl`, `git`, `openssl-devel`, `protobuf-compiler`, `lsof`, `rustup` |
-
-When you pass `--frontend`, `pop install` also installs `unzip` on Arch, Ubuntu, and Debian.
-
 ### Rust toolchain setup
 
 `pop install` installs or updates rustup, then:
@@ -91,7 +87,7 @@ When you pass `--frontend`, `pop install` also installs `unzip` on Arch, Ubuntu,
 - Installs components: `cargo`, `clippy`, `rust-analyzer`, `rust-src`, `rust-std`, `rustc`, `rustfmt`
 
 
-> Pop CLI targets ink! v6 by default in the latest releases. If you need ink! v5 support, install version `0.10.0`:
+> **Compatibility notes:** Pop CLI targets ink! v6 by default in the latest releases. If you need ink! v5 support, install version `0.10.0`:
 >
 > ```bash
 > cargo install --locked pop-cli --version 0.10.0
@@ -111,9 +107,21 @@ This will install:
 
 If Bun installs successfully but is not on your PATH yet, Pop CLI checks the default location at `~/.bun/bin/bun`.
 
-### External scripts
+## 3. Advanced details
 
-`pop install` may download and run external scripts when dependencies are missing, including the official installers for Homebrew, rustup, nvm, and Bun.
+### OS packages and behavior
+
+If your OS/distro is unsupported, `pop install` prints a warning and exits without installing OS packages or tooling.
+
+| OS | Package manager | Packages installed |
+| --- | --- | --- |
+| macOS | Homebrew | `homebrew`, `protobuf`, `openssl`, `cmake`, `rustup` |
+| Arch (or compatible) | `pacman` | `curl`, `git`, `clang`, `make`, `protobuf`, `rustup` |
+| Ubuntu (or compatible) | `apt` | `git`, `clang`, `curl`, `libssl-dev`, `protobuf-compiler`, `lsof`, `pkg-config`, `rustup` |
+| Debian (or compatible) | `apt` | `git`, `clang`, `curl`, `libssl-dev`, `llvm`, `libudev-dev`, `make`, `protobuf-compiler`, `lsof`, `rustup` |
+| Red Hat (or compatible) | `yum` | `gcc`, `gcc-c++`, `make`, `cmake`, `pkgconf`, `pkgconf-pkg-config`, `clang`, `curl`, `git`, `openssl-devel`, `protobuf-compiler`, `lsof`, `rustup` |
+
+When you pass `--frontend`, `pop install` also installs `unzip` on Arch, Ubuntu, and Debian.
 
 **Need help?**
 

--- a/welcome/install-pop-cli.md
+++ b/welcome/install-pop-cli.md
@@ -15,6 +15,14 @@ layout:
 
 # Install Pop CLI
 
+> **Quick install (macOS/Linux with Homebrew)**
+>
+> ```bash
+> brew install r0gue-io/pop-cli/pop
+> ```
+>
+> Need Homebrew? Follow [Install Homebrew](#install-homebrew-if-not-installed).
+
 ## 1. Install Pop CLI
 
 ### 1.1 For macOS and Linux (Homebrew)
@@ -65,11 +73,13 @@ cargo install --force --locked pop-cli
 
 ## 2. Set up your environment
 
+> **Recommended next step:** Run `pop install` to set up OS packages, Rust tooling, and optional frontend dependencies.
+>
 ```bash
 pop install
 ```
 
-`pop install` (alias `pop i`) installs OS packages, Rust tooling, and optional frontend dependencies.
+> **Warning:** `pop install` may download and run external scripts when dependencies are missing, including the official installers for Homebrew, rustup, nvm, and Bun.
 
 ### Install command flags
 
@@ -82,20 +92,6 @@ pop install
 
 By default, `pop install` prompts you before installing OS packages and frontend dependencies. Use `-y` to skip all prompts.
 
-### OS packages and behavior
-
-If your OS/distro is unsupported, `pop install` prints a warning and exits without installing OS packages or tooling.
-
-| OS | Package manager | Packages installed |
-| --- | --- | --- |
-| macOS | Homebrew | `homebrew`, `protobuf`, `openssl`, `cmake`, `rustup` |
-| Arch (or compatible) | `pacman` | `curl`, `git`, `clang`, `make`, `protobuf`, `rustup` |
-| Ubuntu (or compatible) | `apt` | `git`, `clang`, `curl`, `libssl-dev`, `protobuf-compiler`, `lsof`, `pkg-config`, `rustup` |
-| Debian (or compatible) | `apt` | `git`, `clang`, `curl`, `libssl-dev`, `llvm`, `libudev-dev`, `make`, `protobuf-compiler`, `lsof`, `rustup` |
-| Red Hat (or compatible) | `yum` | `gcc`, `gcc-c++`, `make`, `cmake`, `pkgconf`, `pkgconf-pkg-config`, `clang`, `curl`, `git`, `openssl-devel`, `protobuf-compiler`, `lsof`, `rustup` |
-
-When you pass `--frontend`, `pop install` also installs `unzip` on Arch, Ubuntu, and Debian.
-
 ### Rust toolchain setup
 
 `pop install` installs or updates rustup, then:
@@ -104,7 +100,7 @@ When you pass `--frontend`, `pop install` also installs `unzip` on Arch, Ubuntu,
 - Adds the `wasm32-unknown-unknown` target
 - Installs components: `cargo`, `clippy`, `rust-analyzer`, `rust-src`, `rust-std`, `rustc`, `rustfmt`
 
-> Pop CLI targets ink! v6 by default in the latest releases. If you need ink! v5 support, install version `0.10.0`:
+> **Compatibility notes:** Pop CLI targets ink! v6 by default in the latest releases. If you need ink! v5 support, install version `0.10.0`:
 >
 > ```bash
 > cargo install --locked pop-cli --version 0.10.0
@@ -126,9 +122,21 @@ If Bun installs successfully but is not on your PATH yet, Pop CLI checks the def
 
 These dependencies are automatically checked when you use the `--with-frontend` flag with `pop new chain` or `pop new contract`.
 
-### External scripts
+## 3. Advanced details
 
-`pop install` may download and run external scripts when dependencies are missing, including the official installers for Homebrew, rustup, nvm, and Bun.
+### OS packages and behavior
+
+If your OS/distro is unsupported, `pop install` prints a warning and exits without installing OS packages or tooling.
+
+| OS | Package manager | Packages installed |
+| --- | --- | --- |
+| macOS | Homebrew | `homebrew`, `protobuf`, `openssl`, `cmake`, `rustup` |
+| Arch (or compatible) | `pacman` | `curl`, `git`, `clang`, `make`, `protobuf`, `rustup` |
+| Ubuntu (or compatible) | `apt` | `git`, `clang`, `curl`, `libssl-dev`, `protobuf-compiler`, `lsof`, `pkg-config`, `rustup` |
+| Debian (or compatible) | `apt` | `git`, `clang`, `curl`, `libssl-dev`, `llvm`, `libudev-dev`, `make`, `protobuf-compiler`, `lsof`, `rustup` |
+| Red Hat (or compatible) | `yum` | `gcc`, `gcc-c++`, `make`, `cmake`, `pkgconf`, `pkgconf-pkg-config`, `clang`, `curl`, `git`, `openssl-devel`, `protobuf-compiler`, `lsof`, `rustup` |
+
+When you pass `--frontend`, `pop install` also installs `unzip` on Arch, Ubuntu, and Debian.
 **Need help?**
 
 Ask on [Polkadot Stack Exchange](https://polkadot.stackexchange.com/) (tag it [`pop`](https://substrate.stackexchange.com/tags/pop/info)) or drop by [our Telegram](https://t.me/onpopio). We're here to help!


### PR DESCRIPTION
## Summary
- document pop install flags, prompts, and alias
- add OS package lists and frontend unzip behavior
- describe rustup/toolchain setup and external installer scripts

## Testing
- not run (docs-only)
