### PR TITLE
docs: update pop new command docs (prerelease)

### DIFF
--- a/pop-cli-for-appchains/SUMMARY.md
+++ b/pop-cli-for-appchains/SUMMARY.md
@@ -11,6 +11,7 @@
 ## GUIDES
 
 * [Create a new chain](guides/create-a-new-chain.md)
+* [Create a new pallet](guides/create-a-new-pallet.md)
 * [Build](guides/build-your-chain.md)
   * [Build your chain specification](guides/build-spec.md)
   * [Build your runtime deterministically](guides/build-deterministic-runtime.md)

--- a/pop-cli-for-appchains/guides/create-a-new-chain.md
+++ b/pop-cli-for-appchains/guides/create-a-new-chain.md
@@ -6,19 +6,77 @@ Use the interactive prompt to scaffold a chain:
 pop new chain
 ```
 
+If you run `pop new` without a subcommand, Pop CLI prompts you to choose between chain, pallet, and contract. You can also use the top-level alias `pop n`.
+
+## Command overview
+
+```bash
+pop new --list
+pop new chain --list
+pop new chain <NAME>
+```
+
+`pop new --list` prints the available chain and contract templates (based on which features are enabled) and exits. `pop new chain --list` prints only chain templates and exits.
+
+### Command map
+
+- `pop new` (alias: `pop n`)
+- `pop new chain` (aliases: `pop new C`, `pop new p`, `pop new parachain`)
+- `pop new pallet` (alias: `pop new P`)
+- `pop new contract` (alias: `pop new c`)
+
+## Templates
+
 Available templates:
 
-- Pop
-  - Standard
-  - Assets
-  - Contracts
-- OpenZeppelin
-  - Generic Runtime Template
-  - EVM Template
-- Parity
-  - Polkadot SDK's Parachain Template
+- Pop: Standard, Assets, Contracts
+- OpenZeppelin: Generic Runtime Template, EVM Template
+- Parity: Polkadot SDK's Parachain Template
+
+Pop CLI validates provider and template compatibility. If you choose a template that the provider does not support, the command exits with an error. Deprecated templates still appear in the prompt, but Pop CLI warns when you select them.
 
 > Note: Some upstream template names and binaries still say "parachain", this is a Polkadot Chain.
+
+## Options
+
+| Flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--provider` | string | `pop` | Template provider (`pop`, `openzeppelin`, `parity`). |
+| `--template`, `-t` | string | provider default | Template name. |
+| `--release-tag`, `-r` | string | latest | Release tag to use for the template. |
+| `--symbol`, `-s` | string | `UNIT` | Token symbol. |
+| `--decimals`, `-d` | number | `12` | Token decimals. |
+| `--endowment`, `-e` | string | `1u64 << 60` | Initial endowment for dev accounts. |
+| `--verify`, `-v` | boolean | `false` | Verify commit SHA when fetching license and releases. |
+| `--list`, `-l` | boolean | `false` | List templates and exit. |
+| `--with-frontend`, `-f[=<TEMPLATE>]` | string | none | Scaffold a frontend template. Use `=` when providing a value. |
+| `--package-manager` | string | auto | Package manager for frontend scaffolding. Requires `--with-frontend`. |
+
+Token customization options (`--symbol`, `--decimals`, `--endowment`) are only supported for Pop templates and the Parity Generic template. If you pass these options for other templates, Pop CLI warns and proceeds with defaults.
+
+### Endowment validation
+
+`--endowment` accepts a plain integer (for example `1000000`) or a left-shift expression (`1u64 << 60`). If Pop CLI cannot parse the value, it warns and asks whether to fall back to the default endowment. If you decline, the command exits without generating a chain.
+
+### Release and license selection
+
+Pop CLI prints the template license before generation. It then offers the latest three releases that match the template's supported versions. If no matching releases are found and the template declares supported versions, Pop CLI exits with an error. If the template does not declare supported versions, Pop CLI warns and uses the default branch.
+
+## Examples
+
+```bash
+# Interactive chain creation
+pop new chain
+
+# List chain templates
+pop new chain --list
+
+# Specify provider/template explicitly
+pop new chain my-chain --provider pop --template r0gue-io/base-parachain
+
+# Provide token customization in CLI mode
+pop new chain my-chain --symbol DOT --decimals 10 --endowment 1000000
+```
 
 ## Adding a frontend
 
@@ -34,13 +92,18 @@ The interactive prompt will ask you if you want to include a frontend template:
 pop new chain
 ```
 
+If you choose to add a frontend, Pop CLI auto-selects the frontend template because only one exists. If you pass `--with-frontend` without a value, Pop CLI uses the same auto-selection behavior.
+
 ### CLI mode
 
-You can specify the frontend template directly:
+You can specify the frontend template directly. When you provide a value, you must use `=`:
 
 ```bash
 # With default frontend template selection
 pop new chain my-chain --with-frontend
+
+# With specific frontend template
+pop new chain my-chain --with-frontend=create-dot-app
 ```
 
 ### Frontend dependencies
@@ -55,6 +118,10 @@ You can also install frontend dependencies separately using:
 pop install -y --frontend
 ```
 
+### Package manager selection
+
+`--package-manager` only works with `--with-frontend`. If you do not provide it, Pop CLI auto-detects in this order: `pnpm`, `bun`, `yarn`, `npm`.
+
 ### Running the frontend
 
 After scaffolding your chain with a frontend, you can start the frontend development server from your generated chain folder with:
@@ -64,8 +131,6 @@ pop up frontend
 ```
 
 This command starts the frontend dev server for your chain project.
-
 **Need help?**
 
 Ask on [Polkadot Stack Exchange](https://polkadot.stackexchange.com/) (tag it [`pop`](https://substrate.stackexchange.com/tags/pop/info)) or drop by [our Telegram](https://t.me/onpopio). We're here to help!
-

--- a/pop-cli-for-appchains/guides/create-a-new-pallet.md
+++ b/pop-cli-for-appchains/guides/create-a-new-pallet.md
@@ -1,0 +1,69 @@
+# Create a new pallet
+
+Use the interactive prompt to scaffold a pallet:
+
+```bash
+pop new pallet
+```
+
+If you run `pop new` without a subcommand, Pop CLI prompts you to choose between chain, pallet, and contract. You can also use the top-level alias `pop n`.
+
+## Command overview
+
+```bash
+pop new pallet
+pop new pallet <PATH>
+pop new pallet advanced
+```
+
+## Options
+
+| Argument/Flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `<PATH>` | string | interactive | Path or name for the pallet. If omitted, Pop CLI prompts for a path. |
+| `--authors`, `-a` | string | `Anonymous` | Author name(s) for the pallet metadata. |
+| `--description`, `-d` | string | `Frame Pallet` | Pallet description. |
+
+## Advanced mode
+
+Use `advanced` to unlock more customization:
+
+```bash
+pop new pallet <PATH> advanced
+```
+
+If you do not pass any advanced flags, Pop CLI runs an interactive prompt. If you pass any advanced flags, Pop CLI skips prompts and uses your inputs.
+
+| Flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--config-common-types`, `-c` | list | none | Add common config types to the config trait. Pass multiple values separated by spaces. |
+| `--default-config`, `-d` | boolean | `false` | Add default config implementation (requires at least one config common type). |
+| `--storage`, `-s` | list | none | Add storage items to the pallet. Pass multiple values separated by spaces. |
+| `--genesis-config`, `-g` | boolean | `false` | Add a genesis config. |
+| `--custom-origin`, `-o` | boolean | `false` | Add a custom origin. |
+
+Run `pop new pallet advanced --help` to see the available values for `--config-common-types` and `--storage`.
+
+## Behavior notes
+
+- If the pallet path is inside a Rust workspace, Pop CLI adds the pallet to the workspace manifest.
+- Pop CLI runs `cargo fmt --all` after generation. If formatting fails, the pallet is still generated.
+
+## Examples
+
+```bash
+# Interactive pallet creation
+pop new pallet
+
+# Create a pallet in the current directory
+pop new pallet my-pallet
+
+# Create a pallet in a nested directory
+pop new pallet pallets/my-pallet
+
+# Advanced interactive mode
+pop new pallet my-pallet advanced
+
+# Advanced non-interactive mode
+pop new pallet my-pallet advanced --config-common-types runtime-origin currency --storage storage-value storage-map --default-config --genesis-config --custom-origin
+```

--- a/pop-cli-for-smart-contracts/guides/create-a-new-contract.md
+++ b/pop-cli-for-smart-contracts/guides/create-a-new-contract.md
@@ -1,18 +1,51 @@
 # Create a new contract
 
-To view all available smart contract templates run:
+Use the interactive prompt to scaffold a contract:
 
 ```bash
 pop new contract
 ```
 
-To start a new contract, e.g. ERC20, run:
+If you run `pop new` without a subcommand, Pop CLI prompts you to choose a project type. You can also use the top-level alias `pop n`.
+
+## Command overview
 
 ```bash
+pop new --list
+pop new contract --list
+pop new contract <NAME>
+```
+
+`pop new --list` prints the available chain and contract templates (based on which features are enabled) and exits. `pop new contract --list` prints only contract templates and exits.
+
+### Command map
+
+- `pop new` (alias: `pop n`)
+- `pop new contract` (alias: `pop new c`)
+
+## Options
+
+| Flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--template`, `-t` | string | prompt | Contract template name. |
+| `--list`, `-l` | boolean | `false` | List templates and exit. |
+| `--with-frontend`, `-f[=<TEMPLATE>]` | string | none | Scaffold a frontend template. Use `=` when providing a value. |
+| `--package-manager` | string | auto | Package manager for frontend scaffolding. Requires `--with-frontend`. |
+
+## Examples
+
+```bash
+# Interactive contract creation
+pop new contract
+
+# List contract templates
+pop new contract --list
+
+# Create a new contract using a template
 pop new contract my_erc20 --template erc20
 ```
 
-Then open the generated `my_erc20` directory to start developing your contract!
+Pop CLI validates the contract name derived from your path. If it is invalid, the command stops without generating a contract.
 
 ## Adding a frontend
 
@@ -29,9 +62,11 @@ The interactive prompt will ask you to select a frontend template:
 pop new contract my_contract
 ```
 
+If you pass `--with-frontend` without a value, Pop CLI prompts you to pick a frontend template.
+
 ### CLI mode
 
-You can specify the frontend template directly:
+You can specify the frontend template directly. When you provide a value, you must use `=`:
 
 ```bash
 # With default frontend template selection
@@ -55,16 +90,23 @@ You can also install frontend dependencies separately using:
 pop install -y --frontend
 ```
 
+### Package manager selection
+
+`--package-manager` only works with `--with-frontend`. If you do not provide it, Pop CLI auto-detects in this order: `pnpm`, `bun`, `yarn`, `npm`. The `inkathon` template requires Bun, so Pop CLI ignores any other package manager you specify for `inkathon`.
+
+## Behavior notes
+
+- If the contract path is inside a Rust workspace, Pop CLI adds the contract to the workspace manifest.
+
 ### Running the frontend
 
-After scaffolding your contract with a frontend, you can start the frontend development server from your generated chain folder with:
+After scaffolding your contract with a frontend, you can start the frontend development server from your generated contract folder with:
 
 ```bash
 pop up frontend
 ```
 
 This command starts the frontend dev server for your contract project.
-
 **Need help?**
 
 Ask on [Polkadot Stack Exchange](https://polkadot.stackexchange.com/) (tag it [`pop`](https://substrate.stackexchange.com/tags/pop/info)) or drop by [our Telegram](https://t.me/onpopio). We're here to help!


### PR DESCRIPTION
## Summary
- expand pop new chain and contract docs with options, examples, and behavior notes
- add create-a-new-pallet guide and link it in SUMMARY
- clarify release selection error case and frontend template auto-selection

## Testing
- not run (docs-only)
