### PR TITLE
docs: update pop call guides

### DIFF
--- a/pop-cli-for-appchains/guides/call-a-chain.md
+++ b/pop-cli-for-appchains/guides/call-a-chain.md
@@ -2,26 +2,26 @@
 
 If you run `pop call` without a subcommand, Pop CLI uses `pop call chain` unless it detects a contract project in the current directory. If chain support is disabled and no contract project is detected, it returns an error.
 
-### What Can You Do?
+## What Can You Do?
 
 The `pop call chain` command supports three types of operations:
 
-#### 1. Execute Extrinsics
+### 1. Execute Extrinsics
 
 Submit transactions to the chain by calling dispatchable functions. These require signing and will modify chain state.
 
-#### 2. Query Storage
+### 2. Query Storage
 
 Read storage items from the chain's state. Storage queries don't require signing and can read:
 
 - **Plain storage values** (e.g., System::Number - the current block number)
 - **Storage maps** (e.g., System::Account - account information by address)
 
-#### 3. Read Constants
+### 3. Read Constants
 
 Access constant values defined in the runtime metadata (e.g., System::Version, System::BlockHashCount).
 
-### Interactive Guidance (Recommended)
+## Interactive Guidance (Recommended)
 
 Interact with a chain **using** Pop CLI's interactive guidance by simply entering:
 
@@ -41,11 +41,11 @@ After selecting your chain, you will be prompted to select a pallet, then choose
 After making your selection, you'll be guided through providing any required arguments and (for extrinsics) the account
 to sign the transaction.
 
-### Manual (non-interactive)
+## Manual (non-interactive)
 
 If you prefer not to use interactive prompts, you can call the chain by specifying all the required arguments directly:
 
-#### Executing an Extrinsic
+### Executing an Extrinsic
 
 You can execute an extrinsic by specifying the pallet and function (dispatchable function name) and any arguments.
 
@@ -57,39 +57,47 @@ You can execute an extrinsic by specifying the pallet and function (dispatchable
 pop call chain --pallet System --function remark --args "0x11" --url ws://localhost:9944 --suri //Alice --sudo
 ```
 
-#### Querying Storage
+### Querying Storage
 
 You can query storage items by specifying the pallet and function (storage item name).
-Storage queries return the current value immediately without requiring transaction signing.
+Storage queries return the current value immediately without requiring transaction signing. You do not need `--skip-confirm` for read-only calls.
 If the storage item is a map, provide a key with `--args`. In interactive mode, leave the key blank to query all entries.
 
 ```shell
-pop call chain --pallet Sudo --function Key --url wss://pas-rpc.stakeworld.io -y
+pop call chain --pallet Sudo --function Key --url wss://pas-rpc.stakeworld.io
 ```
 
 ```shell
-pop call chain --pallet System --function Account --args 0xb815821c5b300d1667d5fc081c06cc4b6addffb90464d68d871ee363b01a127c --url wss://pas-rpc.stakeworld.io -y
+pop call chain --pallet System --function Account --args 0xb815821c5b300d1667d5fc081c06cc4b6addffb90464d68d871ee363b01a127c --url wss://pas-rpc.stakeworld.io
 ```
 
 
-#### Reading Constants
+### Reading Constants
 
 Query constant values from the runtime.
 Constants are read directly from metadata and don't require signing or keys.
 
 ```shell
-pop call chain --pallet System --function Version --url wss://pas-rpc.stakeworld.io -y
+pop call chain --pallet System --function Version --url wss://pas-rpc.stakeworld.io
 ```
 
 ```shell
-pop call chain --pallet System --function BlockHashCount --url wss://pas-rpc.stakeworld.io -y
+pop call chain --pallet System --function BlockHashCount --url wss://pas-rpc.stakeworld.io
 ```
 
-### Additional Options
+## Additional Options
 
-#### View Metadata
+### View Metadata
+
+**When do you need signing?**
+
+You need a signer for extrinsics only. Storage queries and constants never require signing.
 
 Use `--metadata` to inspect runtime metadata. If you omit `--pallet`, Pop CLI lists all pallets. If you include `--pallet`, it lists calls, storage, and constants for that pallet. This option conflicts with `--function`, `--args`, `--suri`, `--use-wallet`, `--call`, and `--sudo`.
+
+**Conflicts (compact):**
+
+- `--metadata`: conflicts with `--function`, `--args`, `--suri`, `--use-wallet`, `--call`, `--sudo`
 
 ```shell
 pop call chain --metadata --url ws://localhost:9944/
@@ -99,7 +107,7 @@ pop call chain --metadata --url ws://localhost:9944/
 pop call chain --pallet System --metadata --url ws://localhost:9944/
 ```
 
-#### Sudo Calls
+### Sudo Calls
 
 To dispatch a call with Root origin when the chain's runtime includes `pallet-sudo`, you can wrap the call in a
 `sudo.sudo()` call by using the `--sudo` flag:
@@ -108,7 +116,7 @@ To dispatch a call with Root origin when the chain's runtime includes `pallet-su
 pop call chain --pallet System --function remark --args "0x11" --url ws://localhost:9944 --suri //Alice --sudo
 ```
 
-#### Using Wallet for Signing
+### Using Wallet for Signing
 
 You can use a browser extension wallet to sign extrinsics instead of providing a secret URI:
 
@@ -122,7 +130,7 @@ Or use the shorthand `-w`:
 pop call chain --pallet System --function remark --args "0x11" --url ws://localhost:9944/ -w
 ```
 
-#### Direct Call Data Submission
+### Direct Call Data Submission
 
 If you already have the SCALE-encoded call data and want to directly submit the extrinsic:
 
@@ -145,7 +153,7 @@ pop call chain --call 0x00000411 --url ws://localhost:9944/ --suri //Alice
 └  Call complete.
 ```
 
-#### Skip Confirmation
+### Skip Confirmation
 
 Use the `--skip-confirm` or `-y` flag to automatically submit extrinsics without prompting for confirmation. This also
 prevents the prompt to perform another call:
@@ -158,38 +166,38 @@ If you use `--skip-confirm` with an extrinsic, you must provide a signer with `-
 
 This is particularly useful for scripting and automation.
 
-#### Quick URL Entry
+### Quick URL Entry
 
 When prompted for a chain, you can select "Custom" to quickly type the chain URL manually, accelerating the process when
 you already know the endpoint.
 
-### Examples
+## Examples
 
-#### Example 1: Query Current Block Number
+### Example 1: Query Current Block Number
 
 ```shell
 pop call chain --pallet System --function Number --url ws://localhost:9944/
 ```
 
-#### Example 2: Check an Account Balance
+### Example 2: Check an Account Balance
 
 ```shell
 pop call chain --pallet System --function Account --args "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY" --url ws://localhost:9944/
 ```
 
-#### Example 3: Read Runtime Version
+### Example 3: Read Runtime Version
 
 ```shell
 pop call chain --pallet System --function Version --url ws://localhost:9944/
 ```
 
-#### Example 4: Transfer with Wallet
+### Example 4: Transfer with Wallet
 
 ```shell
 pop call chain --pallet Balances --function transfer_keep_alive --args "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty" "1000000000000" --url wss://rpc.polkadot.io --use-wallet
 ```
 
-#### Example 5: Sudo Call with Auto-confirm
+### Example 5: Sudo Call with Auto-confirm
 
 ```shell
 pop call chain --pallet System --function set_code --args "./runtime.wasm" --url ws://localhost:9944/ --suri //Alice --sudo -y

--- a/pop-cli-for-smart-contracts/guides/call-your-contract.md
+++ b/pop-cli-for-smart-contracts/guides/call-your-contract.md
@@ -3,23 +3,23 @@
 The `pop call contract` command enables interaction with deployed ink! smart contracts.
 If you run `pop call` without a subcommand, Pop CLI uses `pop call contract` when it detects a contract project in the current directory.
 
-### What Can You Do?
+## What Can You Do?
 
 The `pop call contract` command supports three types of operations:
 
-#### 1. Execute Messages
+### 1. Execute Messages
 
 Submit transactions that modify contract state. These operations require signing, consume gas, and wait for on-chain finalization.
 
-#### 2. Query Messages
+### 2. Query Messages
 
 Read contract state without making changes. These read-only calls require no signing, incur no gas costs, and return values instantly.
 
-#### 3. Read Storage
+### 3. Read Storage
 
 Access contract storage fields directly using the storage layout. No signing required and no gas costs.
 
-### Interactive Guidance (Recommended)
+## Interactive Guidance (Recommended)
 
 Interact with your contract **using** Pop CLI's interactive guidance by simply entering:
 
@@ -37,11 +37,11 @@ After selecting your chain, you will be prompted to specify the deployed contrac
 
 After making your selection, you'll be guided through providing any required arguments and (for messages that modify state) the account to sign the transaction.
 
-### Manual (non-interactive)
+## Manual (non-interactive)
 
 If you prefer not to use interactive prompts, you can call your contract by specifying all the required arguments directly:
 
-#### Executing a Message
+### Executing a Message
 
 You can execute a message by specifying the contract path (or the metadata file), contract address, message name, and any arguments.
 
@@ -53,7 +53,7 @@ pop call contract --path ./flipper --contract 0x48550a4bb374727186c55365b7c9c0a1
 pop call contract --path ./my_token --contract 0x48550a4bb374727186c55365b7c9c0a1a31bdafe --message transfer --args "0x1234..." "1000" --execute --url ws://localhost:9944/
 ```
 
-#### Querying Messages
+### Querying Messages
 
 You can query messages by specifying the contract path, contract address, and message name.
 Query messages return the current value immediately without requiring transaction signing.
@@ -62,18 +62,18 @@ Query messages return the current value immediately without requiring transactio
 pop call contract --path ./flipper --contract 0x48550a4bb374727186c55365b7c9c0a1a31bdafe --message get --url ws://localhost:9944/
 ```
 
-#### Reading Storage
+### Reading Storage
 
 Access contract storage fields directly using the storage layout.
-Storage queries return the current value immediately without requiring transaction signing.
+Storage queries return the current value immediately without requiring transaction signing. For direct storage access, pass the storage field name with `--message`.
 
 ```shell
 pop call contract --path ./flipper --contract 0x48550a4bb374727186c55365b7c9c0a1a31bdafe --message value --url ws://localhost:9944/
 ```
 
-### Additional Options
+## Additional Options
 
-#### Execute vs Dry-Run
+### Execute vs Dry-Run
 
 If you omit `--execute`, Pop CLI performs a dry-run and returns the result without submitting a transaction. Use `--execute` to submit the call on-chain.
 
@@ -83,7 +83,11 @@ pop call contract --path ./flipper --contract 0x48550a4bb374727186c55365b7c9c0a1
 
 If you provide `--gas`, you must also provide `--proof-size`. If you do not provide them, Pop CLI estimates them during execution.
 
-#### Using Wallet for Signing
+**When do you need signing?**
+
+You need a signer only for executable messages. Read-only queries and storage reads run without signing.
+
+### Using Wallet for Signing
 
 You can use a browser extension wallet to sign transactions instead of providing a secret URI:
 
@@ -99,7 +103,7 @@ pop call contract --path ./flipper --contract 0x48550a4bb374727186c55365b7c9c0a1
 
 If you make a read-only call (query or storage), Pop CLI ignores `--use-wallet` and runs without a signer.
 
-#### Storage Mapping Keys
+### Storage Mapping Keys
 
 If you read a storage map, use `--storage-mapping-key` to query a specific key. In interactive mode, leave the key blank to fetch all entries.
 
@@ -107,11 +111,11 @@ If you read a storage map, use `--storage-mapping-key` to query a specific key. 
 pop call contract --path ./flipper --contract 0x48550a4bb374727186c55365b7c9c0a1a31bdafe --message value --storage-mapping-key "0x..." --url ws://localhost:9944/
 ```
 
-#### Skip Confirmation
+### Skip Confirmation
 
 Use `--skip-confirm` or `-y` to submit an executable message without additional prompts.
 
-#### Developer Mode
+### Developer Mode
 
 `--dev` is deprecated (since 0.12.0) and will be removed in 0.13.0. Use `--skip-confirm` instead.
 
@@ -119,7 +123,7 @@ Use `--skip-confirm` or `-y` to submit an executable message without additional 
 pop call contract --dev --contract 0x48550a4bb374727186c55365b7c9c0a1a31bdafe --message flip --execute
 ```
 
-### Note on Addresses
+## Note on Addresses
 
 If you're using ink! v6, contract addresses are displayed as 20-byte H160 hashes (for example, `0x48550a4bb374727186c55365b7c9c0a1a31bdafe`).
 


### PR DESCRIPTION
## Summary
- document pop call auto-detect behavior
- add chain metadata and call data notes
- clarify contract execute vs dry-run and deprecated flags

## Testing
- bunx honkit serve
- bunx playwright screenshot http://localhost:4000/pop-cli-for-appchains/guides/call-a-chain.html /tmp/pop-docs-call-a-chain.png
- bunx playwright screenshot http://localhost:4000/pop-cli-for-smart-contracts/guides/call-your-contract.html /tmp/pop-docs-call-your-contract.png