### PR TITLE
docs: tighten guides and add fork interactive flow

### DIFF
--- a/pop-cli-for-appchains/install-pop-cli.md
+++ b/pop-cli-for-appchains/install-pop-cli.md
@@ -8,6 +8,44 @@
 >
 > Need Homebrew? Follow [Install Homebrew](#install-homebrew-if-not-installed).
 
+## Other install options
+
+**Using cargo-binstall** (cross-platform, downloads pre-built binaries when available):
+```bash
+# Install cargo-binstall if you don't have it
+curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+
+# Install pop-cli
+cargo binstall pop-cli --locked
+```
+
+**Using Ubuntu PPA:**
+```bash
+sudo add-apt-repository ppa:r0gue-io/pop
+sudo apt-get update
+sudo apt-get install pop-cli
+```
+> If `add-apt-repository` is not found, install it with `sudo apt-get install software-properties-common`.
+
+**Debian/Ubuntu** (using `.deb` package from GitHub Releases):
+```bash
+sudo dpkg -i pop-cli_*.deb
+```
+
+**Nix/NixOS:**
+```bash
+# Run directly without installing
+nix run github:r0gue-io/pop-cli
+
+# Or install to your profile
+nix profile install github:r0gue-io/pop-cli
+```
+
+**Arch Linux** (using `pacman` with a `.pkg.tar.zst` from GitHub Releases):
+```bash
+sudo pacman -U pop-cli-*.pkg.tar.zst
+```
+
 ## 1. Install Pop CLI
 
 ### 1.1 For macOS and Linux (Homebrew)

--- a/pop-cli-for-smart-contracts/welcome/install-pop-cli.md
+++ b/pop-cli-for-smart-contracts/welcome/install-pop-cli.md
@@ -8,6 +8,44 @@
 >
 > Need Homebrew? Follow [Install Homebrew](#install-homebrew-if-not-installed).
 
+## Other install options
+
+**Using cargo-binstall** (cross-platform, downloads pre-built binaries when available):
+```bash
+# Install cargo-binstall if you don't have it
+curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+
+# Install pop-cli
+cargo binstall pop-cli --locked
+```
+
+**Using Ubuntu PPA:**
+```bash
+sudo add-apt-repository ppa:r0gue-io/pop
+sudo apt-get update
+sudo apt-get install pop-cli
+```
+> If `add-apt-repository` is not found, install it with `sudo apt-get install software-properties-common`.
+
+**Debian/Ubuntu** (using `.deb` package from GitHub Releases):
+```bash
+sudo dpkg -i pop-cli_*.deb
+```
+
+**Nix/NixOS:**
+```bash
+# Run directly without installing
+nix run github:r0gue-io/pop-cli
+
+# Or install to your profile
+nix profile install github:r0gue-io/pop-cli
+```
+
+**Arch Linux** (using `pacman` with a `.pkg.tar.zst` from GitHub Releases):
+```bash
+sudo pacman -U pop-cli-*.pkg.tar.zst
+```
+
 ## 1. Install Pop CLI
 
 ### 1.1 For macOS and Linux (Homebrew)

--- a/welcome/install-pop-cli.md
+++ b/welcome/install-pop-cli.md
@@ -23,6 +23,44 @@ layout:
 >
 > Need Homebrew? Follow [Install Homebrew](#install-homebrew-if-not-installed).
 
+## Other install options
+
+**Using cargo-binstall** (cross-platform, downloads pre-built binaries when available):
+```bash
+# Install cargo-binstall if you don't have it
+curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+
+# Install pop-cli
+cargo binstall pop-cli --locked
+```
+
+**Using Ubuntu PPA:**
+```bash
+sudo add-apt-repository ppa:r0gue-io/pop
+sudo apt-get update
+sudo apt-get install pop-cli
+```
+> If `add-apt-repository` is not found, install it with `sudo apt-get install software-properties-common`.
+
+**Debian/Ubuntu** (using `.deb` package from GitHub Releases):
+```bash
+sudo dpkg -i pop-cli_*.deb
+```
+
+**Nix/NixOS:**
+```bash
+# Run directly without installing
+nix run github:r0gue-io/pop-cli
+
+# Or install to your profile
+nix profile install github:r0gue-io/pop-cli
+```
+
+**Arch Linux** (using `pacman` with a `.pkg.tar.zst` from GitHub Releases):
+```bash
+sudo pacman -U pop-cli-*.pkg.tar.zst
+```
+
 ## 1. Install Pop CLI
 
 ### 1.1 For macOS and Linux (Homebrew)


### PR DESCRIPTION
## Summary
- remove `Prerequisites` sections from docs where tool installation is implicit in this docs set
- keep important constraints inline (for example required features, network needs, project context)
- update the fork guide to document the new interactive `pop fork` flow
- align fork docs with current CLI behavior from `../pop-cli` (optional endpoint, `CHAIN`, `--dev`, `--at`)

## Files
- `pop-cli-for-appchains/guides/fork-a-chain.md`
- `pop-cli-for-appchains/guides/upgrade-polkadot-sdk.md`
- `pop-cli-for-smart-contracts/guides/verify-contract.md`
- `pop-mcp.md`
- `welcome/hackathon-guide.md`

## Notes
- no code/test changes; docs-only update