### PR TITLE
docs: remove prerequisites and add fork interactive flow

### DIFF
--- a/pop-cli-for-appchains/guides/fork-a-chain.md
+++ b/pop-cli-for-appchains/guides/fork-a-chain.md
@@ -5,34 +5,45 @@ description: Fork a live chain and run a local RPC server with pop fork.
 # Fork a chain with Pop CLI
 
 Use `pop fork` (alias: `pop f`) to fork a live chain locally and start an RPC server.
-
-## Prerequisites
-
-- Pop CLI (Command Line Interface) built with the `chain` feature. See [Install Pop CLI](../install-pop-cli.md) or run `cargo install --force --locked pop-cli --features chain`.
+This command requires a Pop CLI build with the `chain` feature enabled.
 
 ## Usage
 
 ```bash
-pop fork -e <ENDPOINT>... [options]
+pop fork [CHAIN] [--endpoint <ENDPOINT>] [options]
 ```
 
 ## Flags and arguments
 
 | Flag or argument | Required | Description |
 | --- | --- | --- |
-| `-e, --endpoint <ENDPOINT>...` | Yes | RPC endpoint URL(s) to fork. Repeat for multiple chains. Parsed as a URL. |
-| `-c, --cache <PATH>` | No | Path to a SQLite cache file. If omitted, Pop uses an in-memory cache. When you fork multiple endpoints, Pop appends `_{index}` before the file extension. |
-| `-p, --port <PORT>` | No | Starting port for RPC servers. When you fork multiple endpoints, Pop increments the port after each server starts. |
+| `CHAIN` | No | Well-known chain to fork (for example: `paseo`, `polkadot`, `kusama`, `westend`). |
+| `-e, --endpoint <ENDPOINT>` | No | RPC endpoint URL to fork. Parsed as a URL. If omitted, Pop starts an interactive chain/endpoint selection flow. |
+| `-c, --cache <PATH>` | No | Path to a SQLite cache file. If omitted, Pop uses an in-memory cache. |
+| `-p, --port <PORT>` | No | Port for the local RPC server. If omitted, Pop auto-selects an available port starting from `9944`. |
 | `--mock-all-signatures` | No | Accept all signatures as valid for dev/testing. Default is to accept only magic signatures (`0xdeadbeef`). Do not use for production or security-sensitive scenarios. |
+| `--dev` | No | Funds well-known development accounts and sets Alice as sudo when the runtime includes `pallet-sudo`. |
+| `--at <BLOCK_NUMBER>` | No | Fork at a specific block number. If omitted, Pop forks at the latest finalized block. |
 | `--log-level <LOG_LEVEL>` | No | Log level for block building. Default: `info`. Values: `off`, `error`, `warn`, `info`, `debug`, `trace`. |
 | `-d, --detach` | No | Run the fork in the background and return immediately. Pop prints the process ID (PID) and a log file path. |
 
 ## Behavior notes
 
+- You can run `pop fork` with no chain/endpoint flags and select a chain endpoint interactively.
+- If you provide `CHAIN`, Pop resolves that chain's known RPC endpoints and falls back across them if needed.
 - Pop waits for Ctrl+C. On shutdown, it stops all servers, clears local storage, and warns if cleanup fails.
 - When you use `--detach`, Pop starts a background process, writes output to a log file, and returns immediately. To stop it, run `pop clean node --pid <PID>` or `kill -9 <PID>`.
 - If you do not specify a fork point, Pop uses the latest finalized block from the remote RPC as the fork point.
 - Storage is fetched lazily from the live chain and cached in SQLite. With `--cache`, the cache is persisted on disk. Without it, Pop uses an in-memory cache.
+
+## Interactive flow
+
+Use interactive mode when you don't want to pass endpoint flags up front:
+
+1. Run `pop fork`.
+2. Select a chain source (for example Local, a known chain, or Custom URL).
+3. If needed, provide a custom RPC endpoint URL.
+4. Pop starts the fork and prints the local WebSocket RPC URL you can connect to.
 
 ## Examples
 
@@ -59,11 +70,6 @@ pop fork -e wss://rpc.polkadot.io --mock-all-signatures
 ```bash
 # Control log verbosity
 pop fork -e wss://rpc.polkadot.io --log-level info
-```
-
-```bash
-# Fork multiple chains
-pop fork -e wss://rpc.polkadot.io -e wss://asset-hub-polkadot-rpc.polkadot.io
 ```
 
 ```bash

--- a/pop-cli-for-appchains/guides/upgrade-polkadot-sdk.md
+++ b/pop-cli-for-appchains/guides/upgrade-polkadot-sdk.md
@@ -7,11 +7,7 @@ description: Upgrade Polkadot SDK dependency versions in a chain project with Po
 Use `pop upgrade` to update Polkadot SDK dependency versions in a chain project. It rewrites entries in your `Cargo.toml` using a known version mapping.
 
 You can also run the command as `pop ug`.
-
-## Prerequisites
-
-- A chain project with a `Cargo.toml`.
-- Network access to fetch available Polkadot SDK versions.
+Use this command in a chain project that has a `Cargo.toml`. Network access is required to fetch available Polkadot SDK versions.
 
 ## Usage
 

--- a/pop-cli-for-smart-contracts/guides/verify-contract.md
+++ b/pop-cli-for-smart-contracts/guides/verify-contract.md
@@ -7,12 +7,7 @@ description: Verify a smart contract by comparing a local build to a reference b
 Use `pop verify` to compare a locally built contract against either a local `.contract` bundle or a deployed contract on a chain.
 
 You can also run the command as `pop v`.
-
-## Prerequisites
-
-- A contract project with a `Cargo.toml`.
-- The contract feature enabled in Pop CLI (this command is not available in chain-only builds).
-- Network access if you are verifying against a deployed contract.
+Use this command in a contract project with a `Cargo.toml`. It requires the contract feature in Pop CLI (not available in chain-only builds), plus network access when verifying against a deployed contract.
 
 ## Usage
 

--- a/pop-mcp.md
+++ b/pop-mcp.md
@@ -16,10 +16,7 @@ layout:
 # Pop MCP
 
 Pop MCP is an MCP server that exposes Pop CLI as structured tools for AI clients (contract + chain workflows).
-
-## Prerequisites
-
-- Pop CLI installed and working:
+Pop CLI must be installed and working:
 
 ```bash
 pop --version

--- a/welcome/hackathon-guide.md
+++ b/welcome/hackathon-guide.md
@@ -15,12 +15,8 @@ Pop CLI simplifies development with:
 - Easy launch and management of local development networks.
 
 > See also: [Quickstart Chain Development with Pop CLI (official Polkadot docs)](https://docs.polkadot.com/develop/toolkit/parachains/quickstart/pop-cli/)
-
-### Prerequisites
-
-Follow the install guide to set up Pop CLI and your environment: [Install Pop CLI](./install-pop-cli.md).
-
-To build Polkadot SDK–based chains, ensure your local toolchain is ready: [Install Polkadot SDK Dependencies](https://docs.polkadot.com/develop/parachains/install-polkadot-sdk/).
+>
+> For Polkadot SDK–based chains, ensure your local toolchain is ready: [Install Polkadot SDK Dependencies](https://docs.polkadot.com/develop/parachains/install-polkadot-sdk/).
 
 ### Contract Development (ink!) <a href="#contract-development" id="contract-development"></a>
 Pop CLI introduces experimental support for [ink! v6 smart contracts](https://use.ink/docs/v6) running on [PolkaVM (RISC-V)](https://github.com/paritytech/polkavm) via `pallet-revive`.


### PR DESCRIPTION
## Summary
- remove `Prerequisites` sections where installation is implicit in these docs
- keep important requirements inline (feature flags, project context, network requirements)
- add interactive `pop fork` flow to the fork guide
- align fork docs with current CLI behavior (optional endpoint, `CHAIN`, `--dev`, `--at`)

## Files
- `pop-cli-for-appchains/guides/fork-a-chain.md`
- `pop-cli-for-appchains/guides/upgrade-polkadot-sdk.md`
- `pop-cli-for-smart-contracts/guides/verify-contract.md`
- `pop-mcp.md`
- `welcome/hackathon-guide.md`

## Notes
- docs-only changes