### PR TITLE
docs: sync post-0.13 CLI changes (+ pending call JSON docs)

### DIFF
--- a/pop-cli-for-appchains/guides/benchmarking/benchmarking-pallets-and-extrinsics.md
+++ b/pop-cli-for-appchains/guides/benchmarking/benchmarking-pallets-and-extrinsics.md
@@ -9,6 +9,19 @@ With Pop CLI, you can benchmark pallets and extrinsics interactively by managing
 pop bench pallet
 ```
 
+For automation, use structured output:
+
+```bash
+pop --json bench pallet --runtime=target/release/pop-runtime-devnet.wasm --pallet pallet_balances --extrinsic transfer_keep_alive --skip-parameters
+```
+
+JSON mode requirements:
+
+- `bench pallet` is the only benchmark command that currently supports `--json`.
+- `--runtime` is required.
+- For non-`--list` runs, `--pallet`, `--extrinsic`, and `--skip-parameters` are required.
+- `--json` cannot be combined with `--json-file`.
+
 Note that the command requires the `frame-omni-bencher` binary to be installed on your local machine.
 
 > Pop CLI will automatically source the `frame-omni-bencher` binary if not found on your local machine.

--- a/pop-cli-for-appchains/guides/build-spec.md
+++ b/pop-cli-for-appchains/guides/build-spec.md
@@ -61,6 +61,28 @@ pop build spec -o ./chain-spec.json \
   --genesis-code
 ```
 
+### JSON mode
+
+Use global `--json` to return a structured response:
+
+```bash
+pop --json build spec \
+  --path ./ \
+  --output ./chain-spec.json \
+  --profile release \
+  --type Local \
+  --chain dev \
+  --protocol-id my-protocol \
+  --default-bootnode true \
+  --genesis-state true \
+  --genesis-code true \
+  --deterministic false \
+  --para-id 2000 \
+  --relay paseo
+```
+
+In JSON mode, interactive prompts are disabled. Missing required flags return an error.
+
 ### Deterministic runtime build and injection (optional)
 
 Pop CLI can build your runtime deterministically using srtool and inject the resulting wasm code into the chain spec

--- a/pop-cli-for-appchains/guides/build-your-chain.md
+++ b/pop-cli-for-appchains/guides/build-your-chain.md
@@ -48,6 +48,16 @@ Most common flags:
 | `--deterministic` | Build the runtime deterministically (requires Docker/Podman). Implies `--only-runtime`. |
 | `--tag <image>` | Use a specific srtool image tag (requires `--deterministic`). |
 
+### JSON output
+
+Use global `--json` for structured output in scripts and CI:
+
+```shell
+pop --json build --path ../my-chain --profile release
+```
+
+For `build spec` in JSON mode, prompts are disabled. Provide all required flags explicitly (for example `--output`, `--profile`, `--type`, `--chain`, `--protocol-id`, `--genesis-state`, `--genesis-code`, `--deterministic`, plus relay/para-id options for parachains).
+
 > [!NOTE]
 > If your workspace has multiple runtime crates, Pop CLI prompts you to choose one.
 

--- a/pop-cli-for-appchains/guides/call-a-chain.md
+++ b/pop-cli-for-appchains/guides/call-a-chain.md
@@ -45,21 +45,6 @@ to sign the transaction.
 
 If you prefer not to use interactive prompts, you can call the chain by specifying all the required arguments directly:
 
-### Upcoming: JSON mode (`#993`, pending merge)
-
-`pop call chain` is planned to support global `--json` with structured envelopes once [`#993`](https://github.com/r0gue-io/pop-cli/pull/993) merges.
-
-Planned usage:
-
-```shell
-pop --json call chain --pallet System --function remark --args 0x11 --url ws://localhost:9944 --suri //Alice --execute
-```
-
-Planned behavior:
-
-- Interactive prompts are disabled in JSON mode; required inputs must be passed via flags.
-- Errors are returned with typed codes for automation (`INVALID_INPUT`, `PROMPT_REQUIRED`, `NETWORK_ERROR`, `INTERNAL`).
-
 #### Executing an Extrinsic
 
 You can execute an extrinsic by specifying the pallet and function (dispatchable function name) and any arguments.
@@ -197,6 +182,21 @@ If you only want to skip the submit confirmation (but keep other interactive pro
 #### Exit Codes for Automation
 
 `pop call chain` exits with a non-zero code when a call fails (for example RPC errors, invalid pallet/function names, or failed submission). This makes shell scripting and CI checks reliable.
+
+### Upcoming: JSON mode (`#993`, pending merge)
+
+`pop call chain` is planned to support global `--json` with structured envelopes once [`#993`](https://github.com/r0gue-io/pop-cli/pull/993) merges.
+
+Planned usage:
+
+```shell
+pop --json call chain --pallet System --function remark --args 0x11 --url ws://localhost:9944 --suri //Alice --execute
+```
+
+Planned behavior:
+
+- Interactive prompts are disabled in JSON mode; required inputs must be passed via flags.
+- Errors are returned with typed codes for automation (`INVALID_INPUT`, `PROMPT_REQUIRED`, `NETWORK_ERROR`, `INTERNAL`).
 
 #### Quick URL Entry
 

--- a/pop-cli-for-appchains/guides/call-a-chain.md
+++ b/pop-cli-for-appchains/guides/call-a-chain.md
@@ -179,6 +179,10 @@ This is particularly useful for scripting and automation.
 
 If you only want to skip the submit confirmation (but keep other interactive prompts), use `--execute`.
 
+#### Exit Codes for Automation
+
+`pop call chain` exits with a non-zero code when a call fails (for example RPC errors, invalid pallet/function names, or failed submission). This makes shell scripting and CI checks reliable.
+
 #### Quick URL Entry
 
 When prompted for a chain, you can select "Custom" to quickly type the chain URL manually, accelerating the process when

--- a/pop-cli-for-appchains/guides/call-a-chain.md
+++ b/pop-cli-for-appchains/guides/call-a-chain.md
@@ -69,6 +69,7 @@ You can query storage items by specifying the pallet and function (storage item 
 Storage queries return the current value immediately without requiring transaction signing.
 You do not need `--skip-confirm` for read-only calls.
 If the storage item is a map, provide a key with `--args`. In interactive mode, leave the key blank to query all entries.
+For composite map keys, you can pass tuple-style arguments (for example `(ASSET_ID,ACCOUNT)`), or provide each key part in order.
 
 ```shell
 pop call chain --pallet Sudo --function Key --url wss://pas-rpc.stakeworld.io -y
@@ -76,6 +77,11 @@ pop call chain --pallet Sudo --function Key --url wss://pas-rpc.stakeworld.io -y
 
 ```shell
 pop call chain --pallet System --function Account --args 0xb815821c5b300d1667d5fc081c06cc4b6addffb90464d68d871ee363b01a127c --url wss://pas-rpc.stakeworld.io -y
+```
+
+```shell
+# Composite-key storage example (tuple-style key)
+pop call chain --pallet Assets --function Account --args '(1984,5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY)' --url ws://localhost:9944/
 ```
 
 

--- a/pop-cli-for-appchains/guides/call-a-chain.md
+++ b/pop-cli-for-appchains/guides/call-a-chain.md
@@ -57,6 +57,12 @@ You can execute an extrinsic by specifying the pallet and function (dispatchable
 pop call chain --pallet System --function remark --args "0x11" --url ws://localhost:9944 --suri //Alice --sudo
 ```
 
+To submit directly without the final "submit extrinsic?" prompt, add `--execute`:
+
+```shell
+pop call chain --pallet System --function remark --args "0x11" --url ws://localhost:9944 --suri //Alice --execute
+```
+
 #### Querying Storage
 
 You can query storage items by specifying the pallet and function (storage item name).
@@ -164,6 +170,8 @@ pop call chain --pallet System --function remark --args "0x11" --url ws://localh
 If you use `--skip-confirm` with an extrinsic, you must provide a signer with `--suri` or `--use-wallet`.
 
 This is particularly useful for scripting and automation.
+
+If you only want to skip the submit confirmation (but keep other interactive prompts), use `--execute`.
 
 #### Quick URL Entry
 

--- a/pop-cli-for-appchains/guides/call-a-chain.md
+++ b/pop-cli-for-appchains/guides/call-a-chain.md
@@ -45,6 +45,21 @@ to sign the transaction.
 
 If you prefer not to use interactive prompts, you can call the chain by specifying all the required arguments directly:
 
+### Upcoming: JSON mode (`#993`, pending merge)
+
+`pop call chain` is planned to support global `--json` with structured envelopes once [`#993`](https://github.com/r0gue-io/pop-cli/pull/993) merges.
+
+Planned usage:
+
+```shell
+pop --json call chain --pallet System --function remark --args 0x11 --url ws://localhost:9944 --suri //Alice --execute
+```
+
+Planned behavior:
+
+- Interactive prompts are disabled in JSON mode; required inputs must be passed via flags.
+- Errors are returned with typed codes for automation (`INVALID_INPUT`, `PROMPT_REQUIRED`, `NETWORK_ERROR`, `INTERNAL`).
+
 #### Executing an Extrinsic
 
 You can execute an extrinsic by specifying the pallet and function (dispatchable function name) and any arguments.

--- a/pop-cli-for-appchains/guides/cleaning.md
+++ b/pop-cli-for-appchains/guides/cleaning.md
@@ -20,6 +20,22 @@ You can also run the command as `pop C`.
 pop clean <cache|node|network> [OPTIONS] [PATH]
 ```
 
+### JSON mode
+
+Use global `--json` for structured output:
+
+```bash
+pop --json clean cache --all
+pop --json clean node --all
+pop --json clean network --all
+```
+
+JSON mode requirements:
+
+- `clean cache`: requires `--all`
+- `clean node`: requires `--all` or `--pid`
+- `clean network`: requires `--all` or `PATH`
+
 ## Examples
 
 ```bash

--- a/pop-cli-for-appchains/guides/create-a-new-chain.md
+++ b/pop-cli-for-appchains/guides/create-a-new-chain.md
@@ -34,6 +34,20 @@ Pop CLI validates template compatibility. Deprecated templates still appear in t
 
 Token customization options (`--symbol`, `--decimals`, `--endowment`) are only supported for Pop templates and the Parity Generic template. If you pass these options for other templates, Pop CLI warns and proceeds with defaults.
 
+### JSON mode
+
+Use global `--json` for scripting:
+
+```bash
+pop --json new chain my-chain --template standard
+```
+
+JSON mode requirements:
+
+- Chain name positional argument is required.
+- `--with-frontend` must include a value (for example `--with-frontend=create-dot-app`).
+- Existing destination paths are not overwritten in JSON mode.
+
 ### Endowment validation
 
 `--endowment` accepts a plain integer (for example `1000000`) or a left-shift expression (`1u64 << 60`). If Pop CLI cannot parse the value, it warns and asks whether to fall back to the default endowment. If you decline, the command exits without generating a chain.

--- a/pop-cli-for-appchains/guides/create-a-new-chain.md
+++ b/pop-cli-for-appchains/guides/create-a-new-chain.md
@@ -14,7 +14,7 @@ Available templates:
 - OpenZeppelin: Generic Runtime Template, EVM Template
 - Parity: Polkadot SDK's Parachain Template
 
-Pop CLI validates provider and template compatibility. If you choose a template that the provider does not support, the command exits with an error. Deprecated templates still appear in the prompt, but Pop CLI warns when you select them.
+Pop CLI validates template compatibility. Deprecated templates still appear in the prompt, but Pop CLI warns when you select them.
 
 > Note: Some upstream template names and binaries still say "parachain", this is a Polkadot Chain.
 
@@ -22,8 +22,7 @@ Pop CLI validates provider and template compatibility. If you choose a template 
 
 | Flag | Type | Default | Description |
 | --- | --- | --- | --- |
-| `--provider` | string | `pop` | Template provider (`pop`, `openzeppelin`, `parity`). |
-| `--template`, `-t` | string | provider default | Template name. |
+| `--template`, `-t` | string | interactive default | Template name. |
 | `--release-tag`, `-r` | string | latest | Release tag to use for the template. |
 | `--symbol`, `-s` | string | `UNIT` | Token symbol. |
 | `--decimals`, `-d` | number | `12` | Token decimals. |
@@ -52,8 +51,8 @@ pop new chain
 # List chain templates
 pop new chain --list
 
-# Specify provider/template explicitly
-pop new chain my-chain --provider pop --template r0gue-io/base-parachain
+# Specify template explicitly
+pop new chain my-chain --template r0gue-io/base-parachain
 
 # Provide token customization in CLI mode
 pop new chain my-chain --symbol DOT --decimals 10 --endowment 1000000

--- a/pop-cli-for-appchains/guides/create-a-new-pallet.md
+++ b/pop-cli-for-appchains/guides/create-a-new-pallet.md
@@ -24,6 +24,20 @@ pop new pallet advanced
 | `--authors`, `-a` | string | `Anonymous` | Author name(s) for the pallet metadata. |
 | `--description`, `-d` | string | `Frame Pallet` | Pallet description. |
 
+### JSON mode
+
+Use global `--json` for non-interactive generation:
+
+```bash
+pop --json new pallet my-pallet
+```
+
+JSON mode requirements:
+
+- Pallet name/path is required.
+- `advanced` mode must include one or more advanced flags (interactive advanced prompts are disabled).
+- Existing destination paths are not overwritten in JSON mode.
+
 ## Advanced mode
 
 Use `advanced` to unlock more customization:

--- a/pop-cli-for-appchains/guides/fork-a-chain.md
+++ b/pop-cli-for-appchains/guides/fork-a-chain.md
@@ -13,6 +13,19 @@ This command requires a Pop CLI build with the `chain` feature enabled.
 pop fork [<CHAIN> | -e <ENDPOINT>] [options]
 ```
 
+### JSON mode
+
+Use global `--json` for structured detached-fork output:
+
+```bash
+pop --json fork paseo --detach
+```
+
+JSON mode requirements:
+
+- `--detach` is required.
+- You must pass either `<CHAIN>` or `--endpoint`.
+
 ## Flags and arguments
 
 | Flag or argument | Required | Description |

--- a/pop-cli-for-appchains/guides/fork-a-chain.md
+++ b/pop-cli-for-appchains/guides/fork-a-chain.md
@@ -17,7 +17,7 @@ pop fork [<CHAIN> | -e <ENDPOINT>] [options]
 
 | Flag or argument | Required | Description |
 | --- | --- | --- |
-| `<CHAIN>` | No | Well-known chain to fork (for example: `paseo`, `polkadot`, `kusama`, `westend`). |
+| `<CHAIN>` | No | Well-known chain to fork (for example: `paseo`, `polkadot`, `kusama`, `westend`, `asset-hub`, `asset-hub-polkadot`). |
 | `-e, --endpoint <ENDPOINT>` | No | RPC endpoint URL to fork. Parsed as a URL. If omitted, Pop starts an interactive chain/endpoint selection flow. |
 | `-c, --cache <PATH>` | No | Path to a SQLite cache file. If omitted, Pop uses an in-memory cache. |
 | `-p, --port <PORT>` | No | Port for the local RPC server. If omitted, Pop auto-selects an available port starting from `9944`. |
@@ -81,6 +81,11 @@ pop fork paseo --dev
 ```bash
 # Fork in the background and return once ready
 pop fork kusama --detach
+```
+
+```bash
+# Fork Asset Hub (Polkadot)
+pop fork asset-hub-polkadot --detach
 ```
 
 ## Example workflow

--- a/pop-cli-for-appchains/guides/launch-a-chain/running-your-chain.md
+++ b/pop-cli-for-appchains/guides/launch-a-chain/running-your-chain.md
@@ -90,7 +90,7 @@ pop --json up network ./network.toml --detach
 
 In JSON mode, `--detach` is required and `--cmd` is not supported.
 
-When detached mode starts, Pop CLI now:
+When detached mode starts, Pop CLI:
 
 - Prints the network base directory and `zombie.json` path.
 - Prints WebSocket URLs for relay and parachain nodes.

--- a/pop-cli-for-appchains/guides/launch-a-chain/running-your-chain.md
+++ b/pop-cli-for-appchains/guides/launch-a-chain/running-your-chain.md
@@ -74,6 +74,22 @@ Congrats! You have now spun up a network with your chain running!
 > Under-the-hood, Pop CLI uses zombienet to spin up the network.\
 > For more advanced network configurations and options consult the [zombienet repo](https://github.com/paritytech/zombienet)
 
+### Detached mode
+
+Use detached mode to keep the network running in the background:
+
+```shell
+pop up network ./network.toml --detach
+```
+
+When detached mode starts, Pop CLI now:
+
+- Prints the network base directory and `zombie.json` path.
+- Prints WebSocket URLs for relay and parachain nodes.
+- Polls endpoints until nodes are responsive, then confirms readiness.
+
+To stop a detached network later, run `pop clean network <path-to-zombie.json>` or `pop clean network --all`.
+
 #### Learning Resources
 
 * 🧑‍🏫 To learn about Polkadot in general, [Polkadot.network](https://polkadot.network/) website is a good starting point.
@@ -83,4 +99,3 @@ Congrats! You have now spun up a network with your chain running!
 **Need help?**
 
 Ask on [Polkadot Stack Exchange](https://polkadot.stackexchange.com/) (tag it [`pop`](https://substrate.stackexchange.com/tags/pop/info)) or drop by [our Telegram](https://t.me/onpopio). We're here to help!
-

--- a/pop-cli-for-appchains/guides/launch-a-chain/running-your-chain.md
+++ b/pop-cli-for-appchains/guides/launch-a-chain/running-your-chain.md
@@ -82,6 +82,14 @@ Use detached mode to keep the network running in the background:
 pop up network ./network.toml --detach
 ```
 
+For structured output, use:
+
+```shell
+pop --json up network ./network.toml --detach
+```
+
+In JSON mode, `--detach` is required and `--cmd` is not supported.
+
 When detached mode starts, Pop CLI now:
 
 - Prints the network base directory and `zombie.json` path.

--- a/pop-cli-for-appchains/guides/test-runtime-upgrades.md
+++ b/pop-cli-for-appchains/guides/test-runtime-upgrades.md
@@ -19,6 +19,16 @@ Commands:
   help  Print this message or the help of the given subcommand(s)
 ```
 
+### JSON mode
+
+Use global `--json` for structured output:
+
+```bash
+pop --json test on-runtime-upgrade --runtime ./target/release/my_runtime.wasm --checks all live --uri wss://rpc1.paseo.popnetwork.xyz
+```
+
+In JSON mode, interactive prompts are disabled. Provide all required runtime/source/check flags explicitly.
+
 ## Test migrations
 
 By running the command `pop test on-runtime-upgrade`, you can test the [Runtime Upgrades](https://docs.polkadot.com/develop/parachains/maintenance/runtime-upgrades/) and [Storage Migrations](https://docs.polkadot.com/develop/parachains/maintenance/storage-migrations/) in a simulated environment.

--- a/pop-cli-for-appchains/guides/upgrade-polkadot-sdk.md
+++ b/pop-cli-for-appchains/guides/upgrade-polkadot-sdk.md
@@ -15,6 +15,16 @@ Use this command in a chain project that has a `Cargo.toml`. Network access is r
 pop upgrade [--path <PATH>] [--version <VERSION>]
 ```
 
+### JSON mode
+
+Use global `--json` for structured output in automation:
+
+```bash
+pop --json upgrade --path /path/to/project --version polkadot-stable2509-1
+```
+
+In JSON mode, `--version` is required because interactive version selection is disabled.
+
 ## Examples
 
 ```bash

--- a/pop-cli-for-appchains/install-pop-cli.md
+++ b/pop-cli-for-appchains/install-pop-cli.md
@@ -113,6 +113,20 @@ pop install
 | `-y`, `--skip-confirm` | Skip confirmation prompts and install everything non-interactively. |
 | `-f`, `--frontend` | Install frontend dependencies (Node.js v20+ and Bun). |
 
+### JSON mode
+
+Use global `--json` for structured automation output:
+
+```bash
+pop --json install --skip-confirm
+pop --json completion --shell zsh --output ~/.zsh/completions/_pop
+```
+
+JSON mode notes:
+
+- `pop --json install` requires `-y/--skip-confirm`.
+- `pop --json completion` requires `--shell`.
+
 ### Interactive prompts
 
 By default, `pop install` prompts you before installing OS packages and frontend dependencies. Use `-y` to skip all prompts.

--- a/pop-cli-for-appchains/install-pop-cli.md
+++ b/pop-cli-for-appchains/install-pop-cli.md
@@ -125,7 +125,7 @@ pop --json completion --shell zsh --output ~/.zsh/completions/_pop
 JSON mode notes:
 
 - `pop --json install` requires `-y/--skip-confirm`.
-- `pop --json completion` requires `--shell`.
+- `pop --json completion` requires a shell via positional `SHELL` or `--shell`.
 
 ### Interactive prompts
 

--- a/pop-cli-for-smart-contracts/guides/build-your-contract.md
+++ b/pop-cli-for-smart-contracts/guides/build-your-contract.md
@@ -28,6 +28,14 @@ Most common flags:
 | `--verifiable` | Build a verifiable contract (deterministic release build). Conflicts with `--release` and `--profile`. |
 | `--image <image>` | Use a custom image for verifiable builds (requires `--verifiable`). |
 
+### JSON output
+
+Use global `--json` for structured output in scripts:
+
+```shell
+pop --json build --path ./my_contract --profile release
+```
+
 > [!NOTE]
 > Verifiable builds require Docker to be running.
 

--- a/pop-cli-for-smart-contracts/guides/call-your-contract.md
+++ b/pop-cli-for-smart-contracts/guides/call-your-contract.md
@@ -41,6 +41,21 @@ After making your selection, you'll be guided through providing any required arg
 
 If you prefer not to use interactive prompts, you can call your contract by specifying all the required arguments directly:
 
+### Upcoming: JSON mode (`#993`, pending merge)
+
+`pop call contract` is planned to support global `--json` with structured envelopes once [`#993`](https://github.com/r0gue-io/pop-cli/pull/993) merges.
+
+Planned usage:
+
+```shell
+pop --json call contract --path ./flipper --contract 0x48550a4bb374727186c55365b7c9c0a1a31bdafe --message flip --suri //Alice --execute --url ws://localhost:9944/
+```
+
+Planned behavior:
+
+- Interactive prompts are disabled in JSON mode; required inputs must be passed via flags.
+- Errors are returned with typed codes for automation (`INVALID_INPUT`, `PROMPT_REQUIRED`, `NETWORK_ERROR`, `INTERNAL`).
+
 #### Executing a Message
 
 You can execute a message by specifying the contract path (or the metadata file), contract address, message name, and any arguments.

--- a/pop-cli-for-smart-contracts/guides/call-your-contract.md
+++ b/pop-cli-for-smart-contracts/guides/call-your-contract.md
@@ -118,6 +118,10 @@ pop call contract --path ./flipper --contract 0x48550a4bb374727186c55365b7c9c0a1
 
 Use `--skip-confirm` or `-y` to submit an executable message without additional prompts.
 
+#### Exit Codes for Automation
+
+`pop call contract` exits with a non-zero code when a call fails (for example RPC failures, bad inputs, or execution errors). This makes it safe to use in scripts and CI pipelines.
+
 #### Developer Mode
 
 Use `--dev` for rapid testing during development. This skips gas prompts and confirmation dialogs:

--- a/pop-cli-for-smart-contracts/guides/call-your-contract.md
+++ b/pop-cli-for-smart-contracts/guides/call-your-contract.md
@@ -41,21 +41,6 @@ After making your selection, you'll be guided through providing any required arg
 
 If you prefer not to use interactive prompts, you can call your contract by specifying all the required arguments directly:
 
-### Upcoming: JSON mode (`#993`, pending merge)
-
-`pop call contract` is planned to support global `--json` with structured envelopes once [`#993`](https://github.com/r0gue-io/pop-cli/pull/993) merges.
-
-Planned usage:
-
-```shell
-pop --json call contract --path ./flipper --contract 0x48550a4bb374727186c55365b7c9c0a1a31bdafe --message flip --suri //Alice --execute --url ws://localhost:9944/
-```
-
-Planned behavior:
-
-- Interactive prompts are disabled in JSON mode; required inputs must be passed via flags.
-- Errors are returned with typed codes for automation (`INVALID_INPUT`, `PROMPT_REQUIRED`, `NETWORK_ERROR`, `INTERNAL`).
-
 #### Executing a Message
 
 You can execute a message by specifying the contract path (or the metadata file), contract address, message name, and any arguments.
@@ -136,6 +121,21 @@ Use `--skip-confirm` or `-y` to submit an executable message without additional 
 #### Exit Codes for Automation
 
 `pop call contract` exits with a non-zero code when a call fails (for example RPC failures, bad inputs, or execution errors). This makes it safe to use in scripts and CI pipelines.
+
+### Upcoming: JSON mode (`#993`, pending merge)
+
+`pop call contract` is planned to support global `--json` with structured envelopes once [`#993`](https://github.com/r0gue-io/pop-cli/pull/993) merges.
+
+Planned usage:
+
+```shell
+pop --json call contract --path ./flipper --contract 0x48550a4bb374727186c55365b7c9c0a1a31bdafe --message flip --suri //Alice --execute --url ws://localhost:9944/
+```
+
+Planned behavior:
+
+- Interactive prompts are disabled in JSON mode; required inputs must be passed via flags.
+- Errors are returned with typed codes for automation (`INVALID_INPUT`, `PROMPT_REQUIRED`, `NETWORK_ERROR`, `INTERNAL`).
 
 #### Developer Mode
 

--- a/pop-cli-for-smart-contracts/guides/create-a-new-contract.md
+++ b/pop-cli-for-smart-contracts/guides/create-a-new-contract.md
@@ -32,6 +32,21 @@ pop new contract <NAME>
 | `--with-frontend`, `-f[=<TEMPLATE>]` | string | none | Scaffold a frontend template. Use `=` when providing a value. |
 | `--package-manager` | string | auto | Package manager for frontend scaffolding. Requires `--with-frontend`. |
 
+### JSON mode
+
+Use global `--json` for non-interactive contract generation:
+
+```bash
+pop --json new contract my_erc20 --template erc20
+```
+
+JSON mode requirements:
+
+- Contract name positional argument is required.
+- `--template` is required.
+- `--with-frontend` must include a value (for example `--with-frontend=typink`).
+- Existing destination paths are not overwritten in JSON mode.
+
 ## Examples
 
 ```bash

--- a/pop-cli-for-smart-contracts/guides/deploy.md
+++ b/pop-cli-for-smart-contracts/guides/deploy.md
@@ -66,6 +66,20 @@ pop up --path ./my_contract \
 
 Alternatively, use `--use-wallet` to [sign via browser wallet](securely-sign-transactions-from-cli.md) (PolkadotJS, Talisman, SubWallet) instead of exposing private keys.
 
+### JSON mode
+
+Use global `--json` for structured deployment output:
+
+```bash
+pop --json up --path ./my_contract --constructor new --args false --suri //Alice --execute
+```
+
+JSON mode constraints for contract deployment:
+
+- `--execute` is required.
+- `--use-wallet` is not supported (provide `--suri`).
+- `--upload-only` is not supported.
+
 ### Gas
 
 Pop CLI performs a dry run to estimate [gas](https://use.ink/basics/gas) before deployment. If you do not pass `--execute`, Pop CLI keeps the dry run result and prompts you before deploying. To find an estimate of how much gas you will need, you can do a "dry-run" of the contract:

--- a/pop-cli-for-smart-contracts/guides/run-your-unit-tests.md
+++ b/pop-cli-for-smart-contracts/guides/run-your-unit-tests.md
@@ -14,6 +14,16 @@ If you pass a single positional value and it isn't a directory, Pop treats it as
 pop test my_test_name
 ```
 
+### JSON mode
+
+Use global `--json` for structured test results:
+
+```bash
+pop --json test
+```
+
+`pop --json test --e2e` is not supported. Run E2E tests without `--json`.
+
 Pop checks for an `ink` dependency. If it finds one, it runs contract tests. If it doesn't, Pop runs `cargo test` for non-contract projects and then checks whether the project is a chain.
 
 To run end-to-end (e2e) tests, for which you need a blockchain running:

--- a/pop-cli-for-smart-contracts/guides/verify-contract.md
+++ b/pop-cli-for-smart-contracts/guides/verify-contract.md
@@ -16,6 +16,14 @@ pop verify [--path <PATH> | PATH] --contract-path <FILE>
 pop verify [--path <PATH> | PATH] --url <URL> --address <ADDRESS> --image <IMAGE>
 ```
 
+### JSON mode
+
+Use global `--json` for structured verification results:
+
+```bash
+pop --json verify --contract-path ./target/ink/my_contract.contract
+```
+
 ## Examples
 
 ```bash

--- a/pop-cli-for-smart-contracts/welcome/install-pop-cli.md
+++ b/pop-cli-for-smart-contracts/welcome/install-pop-cli.md
@@ -124,7 +124,7 @@ pop --json completion --shell zsh --output ~/.zsh/completions/_pop
 JSON mode notes:
 
 - `pop --json install` requires `-y/--skip-confirm`.
-- `pop --json completion` requires `--shell`.
+- `pop --json completion` requires a shell via positional `SHELL` or `--shell`.
 
 ### Interactive prompts
 

--- a/pop-cli-for-smart-contracts/welcome/install-pop-cli.md
+++ b/pop-cli-for-smart-contracts/welcome/install-pop-cli.md
@@ -112,6 +112,20 @@ pop install
 | `-y`, `--skip-confirm` | Skip confirmation prompts and install everything non-interactively. |
 | `-f`, `--frontend` | Install frontend dependencies (Node.js v20+ and Bun). |
 
+### JSON mode
+
+Use global `--json` for structured automation output:
+
+```bash
+pop --json install --skip-confirm
+pop --json completion --shell zsh --output ~/.zsh/completions/_pop
+```
+
+JSON mode notes:
+
+- `pop --json install` requires `-y/--skip-confirm`.
+- `pop --json completion` requires `--shell`.
+
 ### Interactive prompts
 
 By default, `pop install` prompts you before installing OS packages and frontend dependencies. Use `-y` to skip all prompts.

--- a/welcome/install-pop-cli.md
+++ b/welcome/install-pop-cli.md
@@ -126,6 +126,20 @@ pop install
 | `-y`, `--skip-confirm` | Skip confirmation prompts and install everything non-interactively. |
 | `-f`, `--frontend` | Install frontend dependencies (Node.js v20+ and Bun). |
 
+### JSON mode
+
+Use global `--json` for structured automation output:
+
+```bash
+pop --json install --skip-confirm
+pop --json completion --shell zsh --output ~/.zsh/completions/_pop
+```
+
+JSON mode notes:
+
+- `pop --json install` requires `-y/--skip-confirm`.
+- `pop --json completion` requires `--shell`.
+
 ### Interactive prompts
 
 By default, `pop install` prompts you before installing OS packages and frontend dependencies. Use `-y` to skip all prompts.

--- a/welcome/install-pop-cli.md
+++ b/welcome/install-pop-cli.md
@@ -138,7 +138,7 @@ pop --json completion --shell zsh --output ~/.zsh/completions/_pop
 JSON mode notes:
 
 - `pop --json install` requires `-y/--skip-confirm`.
-- `pop --json completion` requires `--shell`.
+- `pop --json completion` requires a shell via positional `SHELL` or `--shell`.
 
 ### Interactive prompts
 


### PR DESCRIPTION
## Summary

This PR updates pop-docs for CLI changes merged after `v0.13.0`, with one separate commit for pending `pop-cli` PR #993.

## Commit-by-commit review map

1. `docs(new-chain): remove --provider usage`
- Removes stale `--provider` docs and examples from `pop new chain`.

2. `docs(fork): add Asset Hub well-known chains`
- Documents `asset-hub` and `asset-hub-polkadot` fork sources.

3. `docs(call-chain): document --execute flag`
- Adds `--execute` guidance for call-chain submissions.

4. `docs(call-chain): add composite storage key guidance`
- Adds composite/tuple storage-key query examples.

5. `docs(call): document non-zero exits on failures`
- Documents non-zero exit behavior for failed chain/contract calls.

6. `docs(up-network): document detached readiness and ws output`
- Documents detached network readiness checks and endpoint output.

7. `docs(json): add merged command JSON-mode guidance`
- Adds JSON mode docs for merged command support and non-interactive requirements.

8. `docs(call-json): document pending #993 JSON behavior`
- Adds dedicated upcoming sections for `pop call chain|contract` JSON mode from pending `pop-cli` PR https://github.com/r0gue-io/pop-cli/pull/993.

## Notes

- The pending `#993` updates are clearly labeled as upcoming/pending in docs.
- Existing untracked generated book artifacts in repo were not touched.
